### PR TITLE
[TM-734, TM-735, TM-736] feat: Blog status management and role-based access control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,6 @@
       "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.14.5",
@@ -2019,7 +2018,6 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3948,7 +3946,6 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -4126,7 +4123,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.2",
@@ -4259,7 +4255,6 @@
       "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.3",
         "array.prototype.flat": "^1.2.4",
@@ -8363,7 +8358,6 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.23.tgz",
       "integrity": "sha512-Q5bo1yYOcH2wbBPP4tGmcY5VKsFkQcjUDh66YjrbneAFB3vNKQwLvteRFLuLiU17rA5SDl3UMcMJLD9VS8ng2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bson": "1.x || 4.0.x",
         "@types/mongodb": "^3.5.27",
@@ -9915,7 +9909,6 @@
       "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },

--- a/src/controllers/blog.controller.js
+++ b/src/controllers/blog.controller.js
@@ -11,12 +11,14 @@ const createBlog = catchAsync(async (req, res) => {
     logger.info(`Create Blog Payload: ${JSON.stringify(req.body, null, 2)}`);
   }
   // Populate author from the authenticated user — never trust client-sent author data
+  // Always force pending on create regardless of what frontend sends
   const blogBody = {
     ...req.body,
     author: {
       id: req.user.id,
       role: req.user.role,
     },
+    status: 'pending',
   };
   const blog = await blogService.createBlog(blogBody);
   res.status(httpStatus.CREATED).send(blog);
@@ -36,6 +38,16 @@ const updateBlog = catchAsync(async (req, res) => {
 
   // Strip any client-sent author field; author is immutable after creation
   const { author: _author, ...updateBody } = req.body;
+
+  if (req.user.role === 'tutor') {
+    // Tutors cannot manually change status
+    delete updateBody.status;
+    // If the blog was rejected, auto-reset to pending on edit
+    if (existing.status === 'rejected') {
+      updateBody.status = 'pending';
+    }
+  }
+
   const blog = await blogService.updateBlogById(req.params.blogId, updateBody);
   res.send(blog);
 });
@@ -43,7 +55,7 @@ const updateBlog = catchAsync(async (req, res) => {
 const getBlogs = catchAsync(async (req, res) => {
   const filter = pick(req.query, ['title', 'status', 'tag']);
   const options = pick(req.query, ['sortBy', 'limit', 'page']);
-  const result = await blogService.queryBlogs(filter, options);
+  const result = await blogService.queryBlogs(filter, options, req.user);
   res.send(result);
 });
 

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -29,4 +29,17 @@ const auth =
       .catch((err) => next(err));
   };
 
+// Optional auth — sets req.user if a valid JWT is present, but does not fail if missing
+const optionalAuth = async (req, res, next) => {
+  return new Promise((resolve) => {
+    passport.authenticate('jwt', { session: false }, (err, user) => {
+      if (user) {
+        req.user = user;
+      }
+      resolve();
+    })(req, res, next);
+  }).then(() => next());
+};
+
 module.exports = auth;
+module.exports.optionalAuth = optionalAuth;

--- a/src/models/blog.model.js
+++ b/src/models/blog.model.js
@@ -51,8 +51,8 @@ const blogSchema = mongoose.Schema(
     ],
     status: {
       type: String,
-      enum: ['pending', 'published', 'draft'],
-      default: 'draft',
+      enum: ['pending', 'approved', 'rejected'],
+      default: 'pending',
       index: true,
     },
     faqs: [

--- a/src/routes/v1/blog.route.js
+++ b/src/routes/v1/blog.route.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const auth = require('../../middlewares/auth');
+const { optionalAuth } = require('../../middlewares/auth');
 const validate = require('../../middlewares/validate');
 const blogValidation = require('../../validations/blog.validation');
 const blogController = require('../../controllers/blog.controller');
@@ -9,7 +10,7 @@ const router = express.Router();
 router
   .route('/')
   .post(auth('manageBlog'), validate(blogValidation.createBlog), blogController.createBlog)
-  .get(validate(blogValidation.getBlogs), blogController.getBlogs);
+  .get(optionalAuth, validate(blogValidation.getBlogs), blogController.getBlogs);
 
 /**
  * GET /v1/blogs/slug/:slug

--- a/src/services/blog.service.js
+++ b/src/services/blog.service.js
@@ -17,17 +17,29 @@ const createBlog = async (blogBody) => {
  * @param {Object} options
  * @returns {Promise<QueryResult>}
  */
-const queryBlogs = async (filter, options) => {
+const queryBlogs = async (filter, options, user) => {
   const query = { ...filter };
   if (filter.tag) {
     query.tags = filter.tag;
     delete query.tag;
   }
 
+  // Role-based status filtering
+  if (!user || user.role === 'user') {
+    // Not logged in or regular user — only approved blogs
+    query.status = 'approved';
+  } else if (user.role === 'tutor') {
+    // Tutor sees approved blogs + their own pending/rejected blogs
+    delete query.status;
+    query.$or = [{ status: 'approved' }, { status: { $in: ['pending', 'rejected'] }, 'author.id': user.id }];
+  } else if (user.role === 'admin') {
+    // Admin sees all blogs — ignore any status filter from query params
+    delete query.status;
+  }
+
   const blogs = await Blog.paginate(query, {
     ...options,
     populate: 'tags relatedArticles',
-    // slug is now included so the frontend can build SEO-friendly links
     select: 'title slug author image content relatedArticles tags faqs status createdAt updatedAt',
   });
 
@@ -89,7 +101,7 @@ const deleteBlogById = async (blogId) => {
  * @returns {Promise<Blog>}
  */
 const updateBlogStatus = async (blogId, status) => {
-  if (!['pending', 'published', 'draft'].includes(status)) {
+  if (!['pending', 'approved', 'rejected'].includes(status)) {
     throw new ApiError(httpStatus.BAD_REQUEST, 'Invalid status');
   }
   return updateBlogById(blogId, { status });

--- a/src/validations/blog.validation.js
+++ b/src/validations/blog.validation.js
@@ -63,7 +63,7 @@ const createBlog = {
         answer: Joi.string().required(),
       })
     ),
-    status: Joi.string().valid('pending', 'published', 'draft'),
+    status: Joi.string().valid('pending', 'approved', 'rejected'),
   }),
 };
 
@@ -85,7 +85,7 @@ const updateBlog = {
           answer: Joi.string().required(),
         })
       ),
-      status: Joi.string().valid('pending', 'published', 'draft'),
+      status: Joi.string().valid('pending', 'approved', 'rejected'),
     })
     .min(1),
 };
@@ -94,7 +94,7 @@ const getBlogs = {
   query: Joi.object().keys({
     title: Joi.string(),
     tags: Joi.array().items(objectId()),
-    status: Joi.string().valid('pending', 'published', 'draft'),
+    status: Joi.string().valid('pending', 'approved', 'rejected'),
     sortBy: Joi.string(),
     limit: Joi.number().integer(),
     page: Joi.number().integer(),
@@ -125,7 +125,7 @@ const updateBlogStatus = {
     blogId: objectId().required(),
   }),
   body: Joi.object().keys({
-    status: Joi.string().valid('pending', 'published', 'draft').required(),
+    status: Joi.string().valid('pending', 'approved', 'rejected').required(),
   }),
 };
 


### PR DESCRIPTION
Ticket:
https://softvilmedia-team.atlassian.net/browse/TM-734
https://softvilmedia-team.atlassian.net/browse/TM-735
https://softvilmedia-team.atlassian.net/browse/TM-736

Summary:
Implemented full blog status management with role-based access control.
Blogs now follow a proper review workflow: pending → approved/rejected,
with tutors able to resubmit rejected blogs.

Changes:

Backend:
* Changed blog status enum from [pending, published, draft]
  to [pending, approved, rejected]
* Default blog status changed from "draft" to "pending"
* Force status: "pending" on every blog creation — frontend cannot override
* Added role-based filtering on GET /v1/blogs:
    - Public / user role → approved blogs only
    - Tutor role → approved + own pending/rejected blogs
    - Admin role → all blogs regardless of status
* Added optionalAuth middleware — reads JWT token if present
  without failing if token is missing
* Applied optionalAuth to GET /v1/blogs so role is detected
  for unauthenticated and authenticated requests
* Tutors cannot manually change blog status via PATCH /v1/blogs/:id
* When tutor edits a rejected blog, status auto-resets to "pending"
* Admin blog status update endpoint now accepts:
  "approved" and "rejected" (replaces "published" and "draft")
* Fixed admin seeing only approved blogs when frontend passes
  ?status=approved — admin filter now ignores query param status

Files changed:
* src/models/blog.model.js
* src/validations/blog.validation.js
* src/services/blog.service.js
* src/controllers/blog.controller.js
* src/routes/v1/blog.route.js
* src/middlewares/auth.js

Root Cause:
* Blog status enum did not include "approved" and "rejected"
* GET /v1/blogs had no auth middleware so req.user was always
  undefined — role-based filtering never executed
* No logic to prevent tutors from setting status manually
* No auto-reset logic when tutor resubmits a rejected blog

Result:
* New blogs always start as "pending" ✅
* Admin sees all blogs including pending and rejected ✅
* Tutors see approved blogs + their own pending/rejected only ✅
* Public sees approved blogs only ✅
* Tutor editing a rejected blog auto-resets status to "pending" ✅
* Tutor cannot manually approve their own blog ✅
* No other features or endpoints affected ✅

Screen 

How shows to admin

<img width="1920" height="1785" alt="screencapture-localhost-4000-blogs-2026-04-17-09_12_26" src="https://github.com/user-attachments/assets/1d725b0b-da5b-46dc-b8a7-800f43129e1f" />

<img width="1920" height="1391" alt="screencapture-localhost-4000-blogs-sffsgfsfgfsfgsrg-2026-04-17-09_13_16" src="https://github.com/user-attachments/assets/d9d50ef8-e9be-49ee-a411-3686ebc105b1" />
Shots

How shows to not logged-in users

<img width="1920" height="1312" alt="screencapture-localhost-4000-blogs-2026-04-17-09_12_10" src="https://github.com/user-attachments/assets/20fefcd2-f84e-4ed4-b262-5ff76258a6a8" />

Checklist:
* Self-reviewed code
* Tested as public (not logged in) — approved blogs only
* Tested as user role — approved blogs only
* Tested as tutor — approved + own pending/rejected visible
* Tested as admin — all blogs visible including rejected
* Tested blog creation — status forced to pending
* Tested tutor editing rejected blog — status resets to pending
* Tested admin approve/reject endpoint
* Verified no other endpoints affected