### PR TITLE
[TM-692, TM-693] feat: Update Preferred Tutor Type values and add Preferred Class Type field

### DIFF
--- a/src/models/requestTutor.model.js
+++ b/src/models/requestTutor.model.js
@@ -59,7 +59,12 @@ const requestTutorSchema = mongoose.Schema(
         },
         preferredTutorType: {
           type: String,
-          enum: ['Part Time Tutors', 'Full Time Tutors', 'Ex / Current Government School Tutors'],
+          enum: ['Private Tutor', 'Government Teacher', 'University Student', 'Coach'],
+          required: true,
+        },
+        preferredClassType: {
+          type: String,
+          enum: ['Online - Individual', 'Online - Group', 'Physical - Individual', 'Physical - Group'],
           required: true,
         },
         duration: {

--- a/src/validations/requestTutor.validation.js
+++ b/src/validations/requestTutor.validation.js
@@ -45,11 +45,18 @@ const createRequestTutor = {
           }),
           assignedTutor: Joi.string().trim().allow('', null).optional(),
           preferredTutorType: Joi.string()
-            .valid('Part Time Tutors', 'Full Time Tutors', 'Ex / Current Government School Tutors')
+            .valid('Private Tutor', 'Government Teacher', 'University Student', 'Coach')
             .required()
             .messages({
               'any.only': 'Preferred Tutor Type must be one of the allowed values',
               'any.required': 'Preferred Tutor Type is required',
+            }),
+          preferredClassType: Joi.string()
+            .valid('Online - Individual', 'Online - Group', 'Physical - Individual', 'Physical - Group')
+            .required()
+            .messages({
+              'any.only': 'Preferred Class Type must be one of the allowed values',
+              'any.required': 'Preferred Class Type is required',
             }),
           duration: Joi.string().valid('30 Minutes', 'One Hour', 'Two Hours').required().messages({
             'any.only': 'Duration must be 30 Minutes, One Hour, or Two Hours',


### PR DESCRIPTION
Ticket:
https://softvilmedia-team.atlassian.net/browse/TM-692
https://softvilmedia-team.atlassian.net/browse/TM-693

Summary:
Updated the Preferred Tutor Type dropdown values and added
a new required Preferred Class Type field to the tutor
request feature.

Changes:

Backend:
* Updated preferredTutorType enum values in model and validation
  Old: Part Time Tutors, Full Time Tutors,
       Ex / Current Government School Tutors
  New: Private Tutor, Government Teacher,
       University Student, Coach

* Added new preferredClassType field inside tutors array
  Valid values: Online - Individual, Online - Group,
                Physical - Individual, Physical - Group
  Required: Yes
  Returned in GET response automatically

Files changed:
* src/models/requestTutor.model.js
* src/validations/requestTutor.validation.js

Frontend:
* Must update preferredTutorType dropdown to use new values
* Must add preferredClassType dropdown to the form
* Must send preferredClassType in the POST payload
* If preferredClassType is missing backend returns 400

Root Cause:
* Old tutor type values were outdated per TM-692 requirements
* Preferred Class Type field was missing from the data model

Result:
* preferredTutorType now accepts updated values ✅
* preferredClassType field added and validated ✅
* GET response includes preferredClassType automatically ✅
* No other fields or features affected ✅

Checklist:
* Self-reviewed code
* Tested POST with new preferredTutorType values
* Tested POST with preferredClassType included
* Tested POST without preferredClassType — returns 400 ✅
* Tested GET response includes preferredClassType ✅
* Verified no other fields affected