### PR TITLE
feat(requestTutor): send assignment notification emails to requester and tutor (TM-696, TM-698)

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -268,6 +268,198 @@ Tuition Lanka – Learn Better, Achieve More
   }
 };
 
+/**
+ * Send email to requester when a tutor is assigned (TM-696)
+ * @param {Object} tutorRequest - the full tutor request document
+ * @param {Object} assignedBlock - the specific tutor block that was assigned
+ * @param {string} subjectName - resolved subject name
+ * @param {string} gradeName - resolved grade name
+ * @param {Object} tutorDoc - the assigned tutor document
+ */
+const sendTutorAssignedToRequester = async (tutorRequest, assignedBlock, subjectName, gradeName, tutorDoc) => {
+  try {
+    const { name, email } = tutorRequest;
+
+    const subject = 'Your Tutor Has Been Assigned – Tuition Lanka';
+
+    const tutorName = tutorDoc ? tutorDoc.fullName : 'N/A';
+    const tutorContact = tutorDoc ? tutorDoc.contactNumber : 'N/A';
+    const tutorEmail = tutorDoc ? tutorDoc.email : 'N/A';
+    const tutorTypes = tutorDoc && tutorDoc.tutorType ? tutorDoc.tutorType.join(', ') : 'N/A';
+    const tutorEducation = tutorDoc ? tutorDoc.highestEducation : 'N/A';
+    const tutorExperience = tutorDoc ? `${tutorDoc.yearsExperience} years` : 'N/A';
+    const tutorIntro = tutorDoc ? tutorDoc.teachingSummary : '';
+    const tutorAcademic = tutorDoc ? tutorDoc.academicDetails : '';
+    const tutorResults = tutorDoc ? tutorDoc.studentResults : '';
+
+    const text = `
+Dear ${name},
+
+Great news! A tutor has been assigned for your tuition request with Tuition Lanka.
+
+Assignment Details
+Grade: ${gradeName || 'N/A'}
+Subject: ${subjectName}
+Duration: ${assignedBlock.duration}
+Frequency: ${assignedBlock.frequency}
+Class Type: ${assignedBlock.preferredClassType}
+
+Your Assigned Tutor
+Name: ${tutorName}
+Contact: ${tutorContact}
+Email: ${tutorEmail}
+Tutor Type: ${tutorTypes}
+Highest Education: ${tutorEducation}
+Years of Experience: ${tutorExperience}
+${tutorIntro ? `\nIntroduction:\n${tutorIntro}` : ''}${
+      tutorAcademic ? `\nTeaching Experience & Achievements:\n${tutorAcademic}` : ''
+    }${tutorResults ? `\nStudent Results / Track Record:\n${tutorResults}` : ''}
+
+Your assigned tutor will be in contact with you shortly to arrange the first session.
+
+If you have any questions, feel free to reach out to us.
+
+Warm regards,
+Tuition Lanka Team
+Tuition Lanka – Learn Better, Achieve More
+`;
+
+    const html = `
+      <div style="font-family: Arial, sans-serif; color:#222; line-height:1.6">
+        <p>Dear <strong>${name}</strong>,</p>
+        <p>Great news! A tutor has been assigned for your tuition request with <strong>Tuition Lanka</strong>.</p>
+
+        <h3>📋 Assignment Details</h3>
+        <ul>
+          <li><strong>Grade:</strong> ${gradeName || 'N/A'}</li>
+          <li><strong>Subject:</strong> ${subjectName}</li>
+          <li><strong>Duration:</strong> ${assignedBlock.duration}</li>
+          <li><strong>Frequency:</strong> ${assignedBlock.frequency}</li>
+          <li><strong>Class Type:</strong> ${assignedBlock.preferredClassType}</li>
+        </ul>
+
+        <h3>👤 Your Assigned Tutor</h3>
+        <ul>
+          <li><strong>Name:</strong> ${tutorName}</li>
+          <li><strong>Contact:</strong> ${tutorContact}</li>
+          <li><strong>Email:</strong> ${tutorEmail}</li>
+          <li><strong>Tutor Type:</strong> ${tutorTypes}</li>
+          <li><strong>Highest Education:</strong> ${tutorEducation}</li>
+          <li><strong>Years of Experience:</strong> ${tutorExperience}</li>
+        </ul>
+
+        <h3>📝 Teaching Profile</h3>
+        ${tutorIntro ? `<p><strong>Introduction:</strong><br/>${tutorIntro}</p>` : ''}
+        ${tutorAcademic ? `<p><strong>Teaching Experience &amp; Achievements:</strong><br/>${tutorAcademic}</p>` : ''}
+        ${tutorResults ? `<p><strong>Student Results / Track Record:</strong><br/>${tutorResults}</p>` : ''}
+
+        <p>Your assigned tutor will be in contact with you shortly to arrange the first session.</p>
+        <p>If you have any questions, feel free to reach out to us.</p>
+
+        <p>Warm regards,<br/>
+        <strong>Tuition Lanka Team</strong><br/>
+        Tuition Lanka – Learn Better, Achieve More</p>
+      </div>
+    `;
+
+    await transport.sendMail({ from: config.email.from, to: email, subject, text, html });
+    logger.info(`TM-696: Tutor assigned email sent to requester: ${email}`);
+  } catch (err) {
+    logger.error('Failed to send tutor assigned email to requester:', err);
+  }
+};
+
+/**
+ * Send email to assigned tutor after assignment (TM-698)
+ * @param {Object} tutorUser - the tutor's User document (has name, email)
+ * @param {Object} tutorRequest - the full tutor request document
+ * @param {Object} assignedBlock - the specific tutor block that was assigned
+ * @param {string} subjectName - resolved subject name
+ * @param {string} gradeName - resolved grade name
+ */
+const sendTutorAssignedToTutor = async (tutorUser, tutorRequest, assignedBlock, subjectName, gradeName) => {
+  try {
+    const { name: tutorName, email: tutorEmail } = tutorUser;
+    const { name: studentName, email: studentEmail, phoneNumber, city, district, medium } = tutorRequest;
+
+    const subject = 'New Tuition Assignment – Tuition Lanka';
+
+    const text = `
+Dear ${tutorName},
+
+Congratulations! You have been assigned a new student through Tuition Lanka.
+
+Student Details
+Name: ${studentName}
+Email: ${studentEmail}
+Phone Number: ${phoneNumber}
+City: ${city}
+District: ${district}
+
+Assignment Details
+Grade: ${gradeName}
+Subject: ${subjectName}
+Medium: ${medium}
+Duration: ${assignedBlock.duration}
+Frequency: ${assignedBlock.frequency}
+Class Type: ${assignedBlock.preferredClassType}
+Preferred Tutor Type: ${assignedBlock.preferredTutorType}
+
+Next Steps
+Please reach out to the student directly using the contact details above to arrange the first session at a mutually convenient time.
+
+If you have any questions or need assistance, feel free to contact us.
+
+Warm regards,
+Tuition Lanka Team
+Tuition Lanka – Learn Better, Achieve More
+`;
+
+    const html = `
+      <div style="font-family: Arial, sans-serif; color:#222; line-height:1.6">
+        <p>Dear <strong>${tutorName}</strong>,</p>
+        <p>Congratulations! You have been assigned a new student through <strong>Tuition Lanka</strong>.</p>
+
+        <h3>👤 Student Details</h3>
+        <ul>
+          <li><strong>Name:</strong> ${studentName}</li>
+          <li><strong>Email:</strong> ${studentEmail}</li>
+          <li><strong>Phone Number:</strong> ${phoneNumber}</li>
+          <li><strong>City:</strong> ${city}</li>
+          <li><strong>District:</strong> ${district}</li>
+        </ul>
+
+        <h3>📋 Assignment Details</h3>
+        <ul>
+          <li><strong>Grade:</strong> ${gradeName}</li>
+          <li><strong>Subject:</strong> ${subjectName}</li>
+          <li><strong>Medium:</strong> ${medium}</li>
+          <li><strong>Duration:</strong> ${assignedBlock.duration}</li>
+          <li><strong>Frequency:</strong> ${assignedBlock.frequency}</li>
+          <li><strong>Class Type:</strong> ${assignedBlock.preferredClassType}</li>
+          <li><strong>Preferred Tutor Type:</strong> ${assignedBlock.preferredTutorType}</li>
+        </ul>
+
+        <h3>✅ Next Steps</h3>
+        <p>
+          Please reach out to the student directly using the contact details above to arrange
+          the first session at a mutually convenient time.
+        </p>
+        <p>If you have any questions or need assistance, feel free to contact us.</p>
+
+        <p>Warm regards,<br/>
+        <strong>Tuition Lanka Team</strong><br/>
+        Tuition Lanka – Learn Better, Achieve More</p>
+      </div>
+    `;
+
+    await transport.sendMail({ from: config.email.from, to: tutorEmail, subject, text, html });
+    logger.info(`TM-698: Assignment email sent to tutor: ${tutorEmail}`);
+  } catch (err) {
+    logger.error('Failed to send assignment email to tutor:', err);
+  }
+};
+
 module.exports = {
   transport,
   sendEmail,
@@ -275,4 +467,6 @@ module.exports = {
   sendVerificationEmail,
   sendTemporaryPasswordEmail,
   sendAcknowledgement,
+  sendTutorAssignedToRequester,
+  sendTutorAssignedToTutor,
 };

--- a/src/services/requestTutor.service.js
+++ b/src/services/requestTutor.service.js
@@ -1,5 +1,5 @@
 const httpStatus = require('http-status');
-const { RequestTutor } = require('../models');
+const { RequestTutor, Tutor, Grade, Subject } = require('../models');
 const ApiError = require('../utils/ApiError');
 const emailService = require('./email.service');
 const logger = require('../config/logger');
@@ -9,6 +9,33 @@ const sendAcknowledgement = async (requestTutorBody) => {
     await emailService.sendAcknowledgement(requestTutorBody);
   } catch (err) {
     logger.error({ err }, 'Failed to send acknowledgement email');
+  }
+};
+
+const sendAssignmentEmails = async (tutorRequest, assignedBlock) => {
+  try {
+    const [tutorDoc, gradeDoc, subjectDoc] = await Promise.all([
+      Tutor.findById(assignedBlock.assignedTutor)
+        .select(
+          'fullName email contactNumber tutorType highestEducation yearsExperience teachingSummary academicDetails studentResults sellingPoints'
+        )
+        .lean(),
+      Grade.findById(tutorRequest.grade).select('title').lean(),
+      Subject.findById(assignedBlock.subject).select('title').lean(),
+    ]);
+
+    const gradeName = gradeDoc ? gradeDoc.title : 'N/A';
+    const subjectName = subjectDoc ? subjectDoc.title : 'N/A';
+    const tutorUser = tutorDoc ? { name: tutorDoc.fullName, email: tutorDoc.email } : null;
+
+    await Promise.all([
+      emailService.sendTutorAssignedToRequester(tutorRequest, assignedBlock, subjectName, gradeName, tutorDoc),
+      tutorUser
+        ? emailService.sendTutorAssignedToTutor(tutorUser, tutorRequest, assignedBlock, subjectName, gradeName)
+        : Promise.resolve(),
+    ]);
+  } catch (err) {
+    logger.error({ err }, 'Failed to send assignment emails');
   }
 };
 
@@ -75,16 +102,22 @@ const updateStatusById = async (requestTutorId, status) => {
  * - assignedTutor as string only: defaults to the first tutor block
  */
 const updateAssignedTutor = async (requestTutorId, assignedTutor, tutorBlockId) => {
+  logger.info(
+    `updateAssignedTutor called: requestTutorId=${requestTutorId}, tutorBlockId=${tutorBlockId}, assignedTutor=${assignedTutor}`
+  );
+
   const tutorRequest = await getRequestTutorById(requestTutorId);
   if (!tutorRequest) {
     throw new ApiError(httpStatus.NOT_FOUND, 'Tutor request not found');
   }
 
+  const blocksToNotify = [];
+
   if (Array.isArray(assignedTutor)) {
-    // Positionally assign each tutor ID to the corresponding tutor block
     assignedTutor.forEach((tutorId, index) => {
       if (tutorRequest.tutors[index]) {
         tutorRequest.tutors[index].assignedTutor = tutorId;
+        blocksToNotify.push({ ...tutorRequest.tutors[index].toObject(), assignedTutor: tutorId });
       }
     });
   } else if (tutorBlockId) {
@@ -93,15 +126,23 @@ const updateAssignedTutor = async (requestTutorId, assignedTutor, tutorBlockId) 
       throw new ApiError(httpStatus.NOT_FOUND, 'Tutor block not found');
     }
     tutorBlock.assignedTutor = assignedTutor;
+    blocksToNotify.push({ ...tutorBlock.toObject(), assignedTutor });
   } else {
     const tutorBlock = tutorRequest.tutors[0];
     if (!tutorBlock) {
       throw new ApiError(httpStatus.NOT_FOUND, 'No tutor blocks found in this request');
     }
     tutorBlock.assignedTutor = assignedTutor;
+    blocksToNotify.push({ ...tutorBlock.toObject(), assignedTutor });
   }
 
   await tutorRequest.save();
+
+  logger.info(`blocksToNotify count: ${blocksToNotify.length}`);
+
+  // Send emails non-blocking — one email pair per assigned block
+  blocksToNotify.forEach((block) => sendAssignmentEmails(tutorRequest, block));
+
   return tutorRequest;
 };
 


### PR DESCRIPTION
## Summary

Implements automated email notifications when a tutor is assigned to a tuition request.

- **TM-696** — Email sent to the student/requester confirming their tutor assignment, including the tutor's full profile (name, contact, education, experience, teaching bio)
- **TM-698** — Email sent to the assigned tutor with student contact details and session specifics (grade, subject, medium, frequency, class type)

## Changes

- `email.service.js` — Two new email functions: `sendTutorAssignedToRequester` and `sendTutorAssignedToTutor` with both plain-text and HTML templates
- `requestTutor.service.js` — `sendAssignmentEmails` helper resolves related documents (Tutor, Grade, Subject) and triggers both emails non-blocking after `updateAssignedTutor` saves

## Behaviour Notes

- Emails fire **non-blocking** — a mail failure never breaks the assignment save
- Covers all three assignment paths: array assign, by tutor block ID, and fallback to first block
- Tutor email is skipped gracefully if the tutor document cannot be resolved

## Test Plan

- [ ] Assign a tutor to a request → verify requester receives email with tutor profile
- [ ] Assign a tutor to a request → verify tutor receives email with student details
- [ ] Simulate missing tutor doc → confirm assignment still saves without error
- [ ] Check logs for `TM-696` and `TM-698` confirmation lines