### PR TITLE
feat: add admin management api endpoints

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -12,7 +12,11 @@ const login = catchAsync(async (req, res) => {
   const { email, password } = req.body;
   const user = await authService.loginUserWithEmailAndPassword(email, password);
   const tokens = await tokenService.generateAuthTokens(user);
-  res.send({ user, tokens });
+  res.send({
+    user,
+    tokens,
+    requirePasswordChange: Boolean(user.forcePasswordReset),
+  });
 });
 
 const logout = catchAsync(async (req, res) => {

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -2,10 +2,27 @@ const httpStatus = require('http-status');
 const pick = require('../utils/pick');
 const ApiError = require('../utils/ApiError');
 const catchAsync = require('../utils/catchAsync');
-const { userService } = require('../services');
+const { userService, tokenService, emailService } = require('../services');
 
 const createUser = catchAsync(async (req, res) => {
   const user = await userService.createUser(req.body);
+  res.status(httpStatus.CREATED).send(user);
+});
+
+const createAdmin = catchAsync(async (req, res) => {
+  const adminBody = {
+    name: req.body.name,
+    email: req.body.email,
+    phoneNumber: req.body.phoneNumber,
+    password: req.body.password,
+    role: 'admin',
+    forcePasswordReset: true,
+  };
+
+  const user = await userService.createUser(adminBody);
+  const resetToken = await tokenService.generateResetPasswordToken(user.email);
+  await emailService.sendAdminInviteEmail(user.email, user.name, resetToken);
+
   res.status(httpStatus.CREATED).send(user);
 });
 
@@ -72,6 +89,7 @@ const generateTempPassword = catchAsync(async (req, res) => {
 
 module.exports = {
   createUser,
+  createAdmin,
   getUsers,
   getUser,
   updateUser,

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -72,6 +72,11 @@ const userSchema = mongoose.Schema(
       type: String,
       trim: true,
     },
+    forcePasswordReset: {
+      type: Boolean,
+      default: false,
+    },
+
     zip: {
       type: String,
       trim: true,

--- a/src/routes/v1/user.route.js
+++ b/src/routes/v1/user.route.js
@@ -5,11 +5,13 @@ const userValidation = require('../../validations/user.validation');
 const userController = require('../../controllers/user.controller');
 
 const router = express.Router();
-// 🌸TODO: This should be changed in the future. The corrected lines are commented below
+
 router
   .route('/')
   .post(auth('manageUsers'), validate(userValidation.createUser), userController.createUser)
   .get(auth('getUsers'), validate(userValidation.getUsers), userController.getUsers);
+
+router.route('/admins').post(auth('manageUsers'), validate(userValidation.createAdmin), userController.createAdmin);
 
 router
   .route('/:userId')

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -267,6 +267,62 @@ Tuition Lanka – Learn Better, Achieve More
     throw new Error('Acknowledgement email failed');
   }
 };
+/**
+ * Send admin invitation email
+ * @param {string} to
+ * @param {string} name
+ * @param {string} password
+ * @returns {Promise}
+ */
+const sendAdminInviteEmail = async (to, name, token) => {
+  try {
+    const adminWebsiteUrl = process.env.ADMIN_WEBSITE_URL || 'http://localhost:3000';
+    const resetUrl = `${adminWebsiteUrl}/reset-password?token=${token}`;
+    const subject = 'Set Up Your Admin Account';
+
+    const text = `
+Hello ${name},
+
+You have been added as an admin on TutorMe.
+
+Please set your password using this link:
+${resetUrl}
+
+This link can be used only once and will expire soon.
+
+Regards,
+TutorMe Team
+`;
+
+    const html = `
+      <div style="font-family: Arial, sans-serif; color:#222; line-height:1.6">
+        <p>Hello <strong>${name}</strong>,</p>
+        <p>You have been added as an <strong>admin</strong> on <strong>TutorMe</strong>.</p>
+        <p>Please set your password by clicking the button below:</p>
+        <p>
+          <a href="${resetUrl}"
+             style="display:inline-block;background:#111827;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;">
+            Set Password
+          </a>
+        </p>
+        <p>If the button does not work, copy and paste this link into your browser:</p>
+        <p style="word-break:break-all;">${resetUrl}</p>
+        <p>Regards,<br/>TutorMe Team</p>
+      </div>
+    `;
+
+    await transport.sendMail({
+      from: config.email.from,
+      to,
+      subject,
+      text,
+      html,
+    });
+  } catch (err) {
+    logger.error(`Failed to send admin invite email to ${to}:`, err);
+    throw new Error('Admin invite email failed');
+  }
+};
 
 module.exports = {
   transport,
@@ -275,4 +331,5 @@ module.exports = {
   sendVerificationEmail,
   sendTemporaryPasswordEmail,
   sendAcknowledgement,
+  sendAdminInviteEmail,
 };

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -3,6 +3,7 @@ const bcrypt = require('bcryptjs');
 const { User } = require('../models');
 const ApiError = require('../utils/ApiError');
 const { generateTempPassword } = require('../utils/generatePassword');
+const tokenService = require('./token.service');
 const emailService = require('./email.service');
 
 /**
@@ -87,33 +88,6 @@ const deleteUserById = async (userId) => {
 };
 
 /**
- * Update user by id
- * @param {ObjectId} userId
- * @param {Object} updateBody
- * @returns {Promise<User>}
- */
-const changePassword = async (userId, updateBody) => {
-  const user = await getUserById(userId);
-
-  if (!user) {
-    throw new ApiError(httpStatus.NOT_FOUND, 'User not found');
-  }
-
-  if (!user || !(await user.isPasswordMatch(updateBody.currentPassword))) {
-    throw new ApiError(httpStatus.BAD_REQUEST, 'Incorrect current password');
-  }
-
-  const payload = {
-    password: updateBody.newPassword,
-  };
-
-  Object.assign(user, payload);
-
-  await user.save();
-  return { message: 'Password updated successfully' };
-};
-
-/**
  * @param {ObjectId} userId
  * @returns {Promise<void>}
  */
@@ -137,6 +111,50 @@ const generateTemporaryPassword = async (userId) => {
     throw new ApiError(httpStatus.INTERNAL_SERVER_ERROR, 'Failed to generate temporary password');
   }
 };
+/**
+ * Create an admin user and email credentials
+ * @param {Object} adminBody
+ * @returns {Promise<User>}
+ */
+const createAdminUser = async (adminBody) => {
+  const { email, name, phoneNumber, password } = adminBody;
+
+  if (await User.isEmailTaken(email)) {
+    throw new ApiError(httpStatus.BAD_REQUEST, 'This email is already in use. Please use a different email.');
+  }
+
+  const user = await User.create({
+    name,
+    email,
+    phoneNumber,
+    password,
+    role: 'admin',
+    forcePasswordReset: true,
+  });
+
+  const resetToken = await tokenService.generateResetPasswordToken(user.email);
+  await emailService.sendAdminInviteEmail(user.email, user.name, resetToken);
+
+  return user;
+};
+
+const changePassword = async (userId, updateBody) => {
+  const user = await getUserById(userId);
+
+  if (!user) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'User not found');
+  }
+
+  if (!user || !(await user.isPasswordMatch(updateBody.currentPassword))) {
+    throw new ApiError(httpStatus.BAD_REQUEST, 'Incorrect current password');
+  }
+
+  user.password = updateBody.newPassword;
+  user.forcePasswordReset = false;
+
+  await user.save();
+  return { message: 'Password updated successfully' };
+};
 
 module.exports = {
   createUser,
@@ -145,6 +163,7 @@ module.exports = {
   getUserByEmail,
   updateUserById,
   deleteUserById,
-  changePassword,
   generateTemporaryPassword,
+  createAdminUser,
+  changePassword,
 };

--- a/src/validations/user.validation.js
+++ b/src/validations/user.validation.js
@@ -97,6 +97,15 @@ const generateTempPassword = {
   }),
 };
 
+const createAdmin = {
+  body: Joi.object().keys({
+    name: Joi.string().required(),
+    email: Joi.string().required().email(),
+    phoneNumber: Joi.string().required(),
+    password: Joi.string().required().custom(password),
+  }),
+};
+
 module.exports = {
   createUser,
   getUsers,
@@ -105,4 +114,5 @@ module.exports = {
   deleteUser,
   changePassword,
   generateTempPassword,
+  createAdmin,
 };


### PR DESCRIPTION
## THE API FLOW

### 1. Create admin
POST /v1/users/admins

Body:
```
{
  "name": "New Admin",
  "email": "newadmin@example.com",
  "phoneNumber": "+94771234567",
  "password": "Admin1234"
}
```
What it does:
- creates the admin with role: "admin"
- sets forcePasswordReset: true
- sends a reset-password email with a token link

### 2. Set new password
POST /v1/auth/reset-password?token=YOUR_TOKEN_HERE

Body:
```
{
  "password": "NewStrongPass123"
}
```
What it does:
- updates the password
- clears forcePasswordReset

### 3. Login
POST /v1/auth/login

Body:
```
{
  "email": "newadmin@example.com",
  "password": "NewStrongPass123"
}
```
What it does:
- allows login only after password reset is completed

### Flow

- Admin creates new admin with POST /v1/users/admins
- New admin receives email with reset link
- New admin opens link and sets password via POST /v1/auth/reset-password?token=...
- New admin logs in with POST /v1/auth/login