### PR TITLE
fix: changing the tuition rates payload

### DIFF
--- a/src/models/tuition-rates.model.js
+++ b/src/models/tuition-rates.model.js
@@ -1,77 +1,61 @@
 const mongoose = require('mongoose');
 const { toJSON, paginate } = require('./plugins');
 
+const rateRangeSchema = new mongoose.Schema(
+  {
+    minimumRate: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+    maximumRate: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+  },
+  { _id: false }
+);
+
 const tuitionRatesSchema = mongoose.Schema(
   {
     subject: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Subject',
+      required: true,
     },
     grade: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Grade',
+      required: true,
     },
-    onlineIndividualTuitionRate: [
-      {
-        maximumRate: {
-          type: String,
-          required: true,
-        },
-        minimumRate: {
-          type: String,
-          required: true,
-        },
-      },
-    ],
-    onlineGroupTuitionRate: [
-      {
-        maximumRate: {
-          type: String,
-          required: true,
-        },
-        minimumRate: {
-          type: String,
-          required: true,
-        },
-      },
-    ],
-    physicalIndividualTuitionRate: [
-      {
-        maximumRate: {
-          type: String,
-          required: true,
-        },
-        minimumRate: {
-          type: String,
-          required: true,
-        },
-      },
-    ],
-    physicalGroupTuitionRate: [
-      {
-        maximumRate: {
-          type: String,
-          required: true,
-        },
-        minimumRate: {
-          type: String,
-          required: true,
-        },
-      },
-    ],
+    universityStudentsRate: {
+      type: rateRangeSchema,
+      required: true,
+    },
+    partTimeTutorRate: {
+      type: rateRangeSchema,
+      required: true,
+    },
+    fullTimeTutorRate: {
+      type: rateRangeSchema,
+      required: true,
+    },
+    moeTeacherRate: {
+      type: rateRangeSchema,
+      required: true,
+    },
   },
   {
     timestamps: true,
   }
 );
+
 tuitionRatesSchema.index({ subject: 1, grade: 1 }, { unique: true });
 
 tuitionRatesSchema.plugin(toJSON);
 tuitionRatesSchema.plugin(paginate);
 
-/**
- * @typedef TuitionRates
- */
 const TuitionRates = mongoose.model('TuitionRates', tuitionRatesSchema);
 
 module.exports = TuitionRates;

--- a/src/validations/tuitionRates.validation.js
+++ b/src/validations/tuitionRates.validation.js
@@ -1,39 +1,31 @@
 const Joi = require('joi');
 const mongoose = require('mongoose');
 
+const rateRange = Joi.object().keys({
+  minimumRate: Joi.number().positive().required(),
+  maximumRate: Joi.number().positive().required(),
+});
+
+const idValidator = Joi.string().custom((value, helpers) => {
+  if (!mongoose.Types.ObjectId.isValid(value)) {
+    return helpers.message('Invalid ID');
+  }
+  return value;
+});
+
 // Create tuition rate validation
 const createTuitionRate = {
   body: Joi.object().keys({
     subject: Joi.string().required(),
     grade: Joi.string().required(),
-    onlineIndividualTuitionRate: Joi.array().items(
-      Joi.object().keys({
-        minimumRate: Joi.string().required(),
-        maximumRate: Joi.string().required(),
-      })
-    ),
-    onlineGroupTuitionRate: Joi.array().items(
-      Joi.object().keys({
-        minimumRate: Joi.string().required(),
-        maximumRate: Joi.string().required(),
-      })
-    ),
-    physicalIndividualTuitionRate: Joi.array().items(
-      Joi.object().keys({
-        minimumRate: Joi.string().required(),
-        maximumRate: Joi.string().required(),
-      })
-    ),
-    physicalGroupTuitionRate: Joi.array().items(
-      Joi.object().keys({
-        minimumRate: Joi.string().required(),
-        maximumRate: Joi.string().required(),
-      })
-    ),
+    universityStudentsRate: rateRange.required(),
+    partTimeTutorRate: rateRange.required(),
+    fullTimeTutorRate: rateRange.required(),
+    moeTeacherRate: rateRange.required(),
   }),
 };
 
-// Get tuition rates validation (supports filtering)
+// Get tuition rates validation
 const getTuitionRates = {
   query: Joi.object().keys({
     subject: Joi.string(),
@@ -47,53 +39,23 @@ const getTuitionRates = {
 // Get a single tuition rate validation
 const getTuitionRate = {
   params: Joi.object().keys({
-    tuitionRatesId: Joi.string().custom((value, helpers) => {
-      if (!mongoose.Types.ObjectId.isValid(value)) {
-        return helpers.message('Invalid ID');
-      }
-      return value;
-    }),
+    tuitionRatesId: idValidator,
   }),
 };
 
 // Update tuition rates validation
 const updateTuitionRates = {
   params: Joi.object().keys({
-    tuitionRatesId: Joi.string().custom((value, helpers) => {
-      if (!mongoose.Types.ObjectId.isValid(value)) {
-        return helpers.message('Invalid ID');
-      }
-      return value;
-    }),
+    tuitionRatesId: idValidator,
   }),
   body: Joi.object()
     .keys({
       subject: Joi.string(),
       grade: Joi.string(),
-      onlineIndividualTuitionRate: Joi.array().items(
-        Joi.object().keys({
-          minimumRate: Joi.string().required(),
-          maximumRate: Joi.string().required(),
-        })
-      ),
-      onlineGroupTuitionRate: Joi.array().items(
-        Joi.object().keys({
-          minimumRate: Joi.string().required(),
-          maximumRate: Joi.string().required(),
-        })
-      ),
-      physicalIndividualTuitionRate: Joi.array().items(
-        Joi.object().keys({
-          minimumRate: Joi.string().required(),
-          maximumRate: Joi.string().required(),
-        })
-      ),
-      physicalGroupTuitionRate: Joi.array().items(
-        Joi.object().keys({
-          minimumRate: Joi.string().required(),
-          maximumRate: Joi.string().required(),
-        })
-      ),
+      universityStudentsRate: rateRange,
+      partTimeTutorRate: rateRange,
+      fullTimeTutorRate: rateRange,
+      moeTeacherRate: rateRange,
     })
     .min(1),
 };
@@ -101,12 +63,7 @@ const updateTuitionRates = {
 // Delete tuition rates validation
 const deleteTuitionRates = {
   params: Joi.object().keys({
-    tuitionRatesId: Joi.string().custom((value, helpers) => {
-      if (!mongoose.Types.ObjectId.isValid(value)) {
-        return helpers.message('Invalid ID');
-      }
-      return value;
-    }),
+    tuitionRatesId: idValidator,
   }),
 };
 


### PR DESCRIPTION
## Changes Made

Changing the tuition rates API payload as the example below. 

```
{
  "subject": "66a1f0b2f3c1c9a7d4e11111",
  "grade": "66a1f0b2f3c1c9a7d4e22222",
  "universityStudentsRate": {
    "minimumRate": 1500,
    "maximumRate": 2500
  },
  "partTimeTutorRate": {
    "minimumRate": 2000,
    "maximumRate": 3500
  },
  "fullTimeTutorRate": {
    "minimumRate": 3000,
    "maximumRate": 5000
  },
  "moeTeacherRate": {
    "minimumRate": 4000,
    "maximumRate": 7000
  }
}
```
