### PR TITLE
Add tutor registration email availability check

### DIFF
--- a/src/controllers/tutor.controller.js
+++ b/src/controllers/tutor.controller.js
@@ -17,6 +17,11 @@ const getTutors = catchAsync(async (req, res) => {
   res.send(result);
 });
 
+const getTutorEmailAvailability = catchAsync(async (req, res) => {
+  const result = await tutorService.getEmailAvailability(req.query.email);
+  res.send(result);
+});
+
 const getTutor = catchAsync(async (req, res) => {
   const tutor = await tutorService.getTutorById(req.params.tutorId);
   if (!tutor) {
@@ -90,6 +95,7 @@ const matchTutorsBySubjects = catchAsync(async (req, res) => {
 module.exports = {
   createTutor,
   getTutors,
+  getTutorEmailAvailability,
   getTutor,
   updateTutor,
   deleteTutor,

--- a/src/routes/v1/tutor.route.js
+++ b/src/routes/v1/tutor.route.js
@@ -12,6 +12,10 @@ router
   .get(validate(tutorValidation.getTutors), tutorController.getTutors);
 
 router
+  .route('/email-availability')
+  .get(validate(tutorValidation.getTutorEmailAvailability), tutorController.getTutorEmailAvailability);
+
+router
   .route('/:tutorId')
   .get(validate(tutorValidation.getTutor), tutorController.getTutor)
   .patch(auth('manageUsers'), validate(tutorValidation.updateTutor), tutorController.updateTutor)

--- a/src/services/tutor.service.js
+++ b/src/services/tutor.service.js
@@ -1,5 +1,5 @@
 const httpStatus = require('http-status');
-const { Tutor } = require('../models');
+const { Tutor, User } = require('../models');
 const ApiError = require('../utils/ApiError');
 const { generateTempPassword } = require('../utils/generatePassword');
 const logger = require('../config/logger');
@@ -20,6 +20,51 @@ const checkEmailSuspended = async (email) => {
 };
 
 /**
+ * Check whether a tutor registration email can be used.
+ * @param {string} email
+ * @returns {Promise<{available: boolean, message: string}>}
+ */
+const getEmailAvailability = async (email) => {
+  const normalizedEmail = email.toLowerCase().trim();
+  const [existingUser, existingTutor] = await Promise.all([
+    User.findOne({ email: normalizedEmail }).select('_id').lean(),
+    Tutor.findOne({ email: normalizedEmail }).select('_id status').lean(),
+  ]);
+
+  if (existingTutor && existingTutor.status === 'suspended') {
+    return {
+      available: false,
+      message: 'This email has been suspended. Please contact admin.',
+    };
+  }
+
+  if (existingUser || existingTutor) {
+    return {
+      available: false,
+      message: 'Email already exists',
+    };
+  }
+
+  return {
+    available: true,
+    message: 'Email is available',
+  };
+};
+
+/**
+ * Ensure the tutor registration email is not already used by a user or tutor.
+ * Throws 400 BAD_REQUEST before any tutor record or notification email is created.
+ * @param {string} email
+ * @returns {Promise<void>}
+ */
+const checkEmailAvailable = async (email) => {
+  const availability = await getEmailAvailability(email);
+  if (!availability.available) {
+    throw new ApiError(httpStatus.BAD_REQUEST, availability.message);
+  }
+};
+
+/**
  * Create a Tutor
  * @param {Object} tutorBody
  * @returns {Promise<Tutor>}
@@ -27,6 +72,7 @@ const checkEmailSuspended = async (email) => {
 const createTutor = async (tutorBody) => {
   // Block suspended emails from re-registering
   await checkEmailSuspended(tutorBody.email);
+  await checkEmailAvailable(tutorBody.email);
 
   const tutor = await Tutor.create({ ...tutorBody, status: 'pending' });
   try {
@@ -182,4 +228,6 @@ module.exports = {
   generateTemporaryPassword,
   findTutorsBySubjects,
   checkEmailSuspended,
+  checkEmailAvailable,
+  getEmailAvailability,
 };

--- a/src/validations/tutor.validation.js
+++ b/src/validations/tutor.validation.js
@@ -206,6 +206,12 @@ const getTutors = {
   }),
 };
 
+const getTutorEmailAvailability = {
+  query: Joi.object().keys({
+    email: Joi.string().email().required(),
+  }),
+};
+
 const getTutor = {
   params: Joi.object().keys({
     tutorId: Joi.string().custom((value, helpers) => {
@@ -456,6 +462,7 @@ const tutorUserProfileFields = {
 module.exports = {
   createTutor,
   getTutors,
+  getTutorEmailAvailability,
   getTutor,
   updateTutor,
   deleteTutor,


### PR DESCRIPTION
## Summary
- Added a tutor email availability endpoint: `GET /v1/tutors/email-availability?email=...`
- Validates the email query param before checking availability
- Checks both `User` and `Tutor` records to prevent duplicate tutor registrations
- Blocks suspended tutor emails with the existing admin-contact message
- Reuses the availability check during tutor creation so duplicate records and notification emails are avoided