### PR TITLE
feat(request-tutor): add tutor matching report email and rejection workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,5 @@ SMTP_PORT=587
 SMTP_USERNAME=email-server-username
 SMTP_PASSWORD=email-server-password
 EMAIL_FROM=support@yourapp.com
+ADMIN_EMAIL=admin@yourapp.com
 #config proper email server

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -23,6 +23,7 @@ const envVarsSchema = Joi.object()
     SMTP_USERNAME: Joi.string().description('username for email server'),
     SMTP_PASSWORD: Joi.string().description('password for email server'),
     EMAIL_FROM: Joi.string().description('the from field in the emails sent by the app'),
+    ADMIN_EMAIL: Joi.string().email().description('the admin email that receives tutor request match reports'),
   })
   .unknown();
 
@@ -65,5 +66,6 @@ module.exports = {
       },
     },
     from: `"Tuition Lanka" <${process.env.EMAIL_FROM}>`,
+    admin: envVars.ADMIN_EMAIL || envVars.EMAIL_FROM,
   },
 };

--- a/src/config/enums.js
+++ b/src/config/enums.js
@@ -19,7 +19,7 @@ const races = ['Sinhalese', 'Tamil', 'Muslim', 'Burgher', 'Others'];
 
 const tutorStatuses = ['pending', 'approved', 'rejected', 'suspended'];
 
-const requestTutorStatuses = ['Pending', 'Approved', 'Tutor Assigned'];
+const requestTutorStatuses = ['Pending', 'Rejected'];
 
 const classTypes = [
   'Online - Individual',

--- a/src/controllers/requestTutor.controllers.js
+++ b/src/controllers/requestTutor.controllers.js
@@ -64,6 +64,11 @@ const updateAssignedTutor = catchAsync(async (req, res) => {
   res.send(updated);
 });
 
+const sendTutorMatchReport = catchAsync(async (req, res) => {
+  const result = await requestTutorService.sendTutorMatchReportToAdmin(req.params.requestTutorId);
+  res.send(result);
+});
+
 module.exports = {
   createTutorRequest,
   getTutorRequests,
@@ -71,4 +76,5 @@ module.exports = {
   deleteTutor,
   updateStatus,
   updateAssignedTutor,
+  sendTutorMatchReport,
 };

--- a/src/controllers/requestTutor.controllers.js
+++ b/src/controllers/requestTutor.controllers.js
@@ -10,7 +10,23 @@ const createTutorRequest = catchAsync(async (req, res) => {
 });
 
 const getTutorRequests = catchAsync(async (req, res) => {
-  const filter = pick(req.query, ['name']);
+  const filter = pick(req.query, [
+    'search',
+    'name',
+    'email',
+    'city',
+    'district',
+    'grade',
+    'medium',
+    'status',
+    'phoneNumber',
+    'subject',
+    'assignedTutor',
+    'preferredTutorType',
+    'preferredClassType',
+    'duration',
+    'frequency',
+  ]);
   const options = {
     ...pick(req.query, ['sortBy', 'limit', 'page']),
   };
@@ -33,9 +49,9 @@ const deleteTutor = catchAsync(async (req, res) => {
 
 const updateStatus = catchAsync(async (req, res) => {
   const { requestTutorId } = req.params;
-  const { status } = req.body;
+  const { status, rejectionReason } = req.body;
 
-  const updated = await requestTutorService.updateStatusById(requestTutorId, status);
+  const updated = await requestTutorService.updateStatusById(requestTutorId, status, rejectionReason);
   res.send(updated);
 });
 

--- a/src/models/requestTutor.model.js
+++ b/src/models/requestTutor.model.js
@@ -46,6 +46,7 @@ const requestTutorSchema = mongoose.Schema(
       type: String,
       enum: requestTutorStatuses,
       required: true,
+      default: 'Pending',
     },
     phoneNumber: {
       type: String,

--- a/src/routes/v1/request-tutor.route.js
+++ b/src/routes/v1/request-tutor.route.js
@@ -28,4 +28,12 @@ router
     requestTutorController.updateAssignedTutor
   );
 
+router
+  .route('/match-tutors/:requestTutorId')
+  .post(
+    auth('manageUsers'),
+    validate(requestTutorValidation.sendTutorMatchReport),
+    requestTutorController.sendTutorMatchReport
+  );
+
 module.exports = router;

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -19,8 +19,8 @@ if (config.env !== 'test') {
  * @param {string} text
  * @returns {Promise}
  */
-const sendEmail = async (to, subject, text) => {
-  const msg = { from: config.email.from, to, subject, text };
+const sendEmail = async (to, subject, text, html) => {
+  const msg = { from: config.email.from, to, subject, text, html };
   await transport.sendMail(msg);
 };
 

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -24,6 +24,14 @@ const sendEmail = async (to, subject, text) => {
   await transport.sendMail(msg);
 };
 
+const escapeHtml = (value) =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
 /**
  * Send reset password email (HTML + Text)
  * @param {string} to
@@ -265,6 +273,88 @@ Tuition Lanka – Learn Better, Achieve More
   } catch (err) {
     logger.error('Failed to send acknowledgement email:', err);
     throw new Error('Acknowledgement email failed');
+  }
+};
+
+/**
+ * Send tutor request rejection email
+ * @param {string} to - Requester's email address
+ * @param {string} requesterName - Requester's name
+ * @param {string} rejectionReason - Admin rejection reason
+ * @param {Object} requestTutorBody - Original request payload
+ * @returns {Promise}
+ */
+const sendRequestTutorRejectedEmail = async (to, requesterName, rejectionReason, requestTutorBody) => {
+  try {
+    const subject = 'Update on Your Tutor Request â€“ TuitionLanka';
+    const safeName = escapeHtml(requesterName || 'there');
+    const safeReason = escapeHtml(rejectionReason || 'No reason provided');
+    const safeCity = escapeHtml(requestTutorBody && requestTutorBody.city ? requestTutorBody.city : 'N/A');
+    const safeDistrict = escapeHtml(requestTutorBody && requestTutorBody.district ? requestTutorBody.district : 'N/A');
+    const safeGrade = escapeHtml(requestTutorBody && requestTutorBody.grade ? requestTutorBody.grade : 'N/A');
+
+    const text = `
+Dear ${requesterName || 'there'},
+
+We reviewed your tutor request and unfortunately we were unable to approve it at this time.
+
+Reason:
+${rejectionReason}
+
+Request details
+Name: ${requesterName || 'N/A'}
+City: ${requestTutorBody && requestTutorBody.city ? requestTutorBody.city : 'N/A'}
+District: ${requestTutorBody && requestTutorBody.district ? requestTutorBody.district : 'N/A'}
+Grade: ${requestTutorBody && requestTutorBody.grade ? requestTutorBody.grade : 'N/A'}
+
+If you would like to submit a new request in the future, you are welcome to do so with updated details.
+
+Regards,
+Tuition Lanka Team
+`;
+
+    const html = `
+      <div style="font-family: Arial, sans-serif; color:#222; line-height:1.7; max-width:600px; margin:0 auto;">
+        <div style="background-color:#dc2626; padding:24px 32px; border-radius:8px 8px 0 0;">
+          <h2 style="color:#ffffff; margin:0; font-size:22px;">Tutor Request Rejected</h2>
+        </div>
+        <div style="background-color:#f9fafb; padding:28px 32px; border:1px solid #e5e7eb; border-top:none; border-radius:0 0 8px 8px;">
+          <p>Dear <strong>${safeName}</strong>,</p>
+          <p>We reviewed your tutor request and unfortunately we were unable to approve it at this time.</p>
+
+          <div style="background-color:#fef2f2; border-left:4px solid #ef4444; padding:16px 20px; border-radius:4px; margin:20px 0;">
+            <p style="margin:0 0 8px 0; color:#7f1d1d;"><strong>Reason provided by our team:</strong></p>
+            <p style="margin:0; color:#991b1b; white-space:pre-wrap;">${safeReason}</p>
+          </div>
+
+          <h3 style="margin-top:24px;">Request details</h3>
+          <ul>
+            <li><strong>Name:</strong> ${safeName}</li>
+            <li><strong>City:</strong> ${safeCity}</li>
+            <li><strong>District:</strong> ${safeDistrict}</li>
+            <li><strong>Grade:</strong> ${safeGrade}</li>
+          </ul>
+
+          <p>If you would like to submit a new request in the future, you are welcome to do so with updated details.</p>
+
+          <p style="margin-top:28px;">
+            Regards,<br/>
+            <strong>Tuition Lanka Team</strong>
+          </p>
+        </div>
+      </div>
+    `;
+
+    await transport.sendMail({
+      from: config.email.from,
+      to,
+      subject,
+      text,
+      html,
+    });
+  } catch (err) {
+    logger.error(`Failed to send tutor request rejected email to ${to}:`, err);
+    throw new Error('Tutor request rejected email failed');
   }
 };
 /**
@@ -788,6 +878,7 @@ module.exports = {
   sendVerificationEmail,
   sendTemporaryPasswordEmail,
   sendAcknowledgement,
+  sendRequestTutorRejectedEmail,
   sendTutorAssignedToRequester,
   sendTutorAssignedToTutor,
   sendTutorRegistrationPendingEmail,

--- a/src/services/requestTutor.service.js
+++ b/src/services/requestTutor.service.js
@@ -1,8 +1,10 @@
 const httpStatus = require('http-status');
+const mongoose = require('mongoose');
 const { RequestTutor, Tutor, Grade, Subject } = require('../models');
 const ApiError = require('../utils/ApiError');
 const emailService = require('./email.service');
 const logger = require('../config/logger');
+const config = require('../config/config');
 
 const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const toArray = (value) => (Array.isArray(value) ? value : [value]);
@@ -125,6 +127,316 @@ const buildTutorRequestQuery = (filter = {}) => {
   return query;
 };
 
+const formatAvailabilitySlot = (slot) => `${slot.day}: ${slot.start} - ${slot.end}`;
+
+const resolveGradeDoc = async (gradeValue) => {
+  if (!gradeValue) {
+    return null;
+  }
+
+  if (mongoose.Types.ObjectId.isValid(gradeValue)) {
+    const byId = await Grade.findById(gradeValue).select('title').lean();
+    if (byId) {
+      return byId;
+    }
+  }
+
+  return Grade.findOne({ title: gradeValue }).select('title').lean();
+};
+
+const resolveSubjectDoc = async (subjectValue) => {
+  if (!subjectValue) {
+    return null;
+  }
+
+  if (mongoose.Types.ObjectId.isValid(subjectValue)) {
+    const byId = await Subject.findById(subjectValue).select('title').lean();
+    if (byId) {
+      return byId;
+    }
+  }
+
+  return Subject.findOne({ title: subjectValue }).select('title').lean();
+};
+
+const buildTutorMatchQuery = (gradeDoc, subjectDoc, requestTutor, tutorBlock) => {
+  const query = {
+    status: 'approved',
+  };
+
+  if (gradeDoc) {
+    query.grades = gradeDoc._id;
+  }
+
+  if (requestTutor.medium) {
+    query.tutorMediums = requestTutor.medium;
+  }
+
+  if (subjectDoc) {
+    query.subjects = subjectDoc._id;
+  }
+
+  if (tutorBlock.preferredTutorType) {
+    query.tutorType = tutorBlock.preferredTutorType;
+  }
+
+  if (tutorBlock.preferredClassType) {
+    query.classType = tutorBlock.preferredClassType;
+  }
+
+  return query;
+};
+
+const buildTutorSummary = (tutor) => {
+  const availability = Array.isArray(tutor.availability) ? tutor.availability : [];
+
+  return {
+    id: tutor._id,
+    fullName: tutor.fullName,
+    contactNumber: tutor.contactNumber,
+    email: tutor.email,
+    tutorType: tutor.tutorType || [],
+    tutorMediums: tutor.tutorMediums || [],
+    preferredLocations: tutor.preferredLocations || [],
+    yearsExperience: tutor.yearsExperience,
+    highestEducation: tutor.highestEducation,
+    academicDetails: tutor.academicDetails || '',
+    teachingSummary: tutor.teachingSummary || '',
+    studentResults: tutor.studentResults || '',
+    sellingPoints: tutor.sellingPoints || '',
+    language: tutor.language || '',
+    timeZone: tutor.timeZone || '',
+    rate: tutor.rate || '',
+    subjects: Array.isArray(tutor.subjects) ? tutor.subjects.map((subject) => subject.title || subject) : [],
+    grades: Array.isArray(tutor.grades) ? tutor.grades.map((grade) => grade.title || grade) : [],
+    availability: availability.map(formatAvailabilitySlot),
+    availabilityCount: availability.length,
+  };
+};
+
+const buildTutorRequestMatchReport = async (requestTutor) => {
+  const [gradeDoc, blockSubjectDocs] = await Promise.all([
+    resolveGradeDoc(requestTutor.grade),
+    Promise.all(
+      (requestTutor.tutors || []).map(async (tutorBlock) => {
+        const subjectDoc = await resolveSubjectDoc(tutorBlock.subject);
+        return {
+          tutorBlock,
+          subjectTitle: subjectDoc ? subjectDoc.title : tutorBlock.subject || 'N/A',
+          subjectDoc,
+        };
+      })
+    ),
+  ]);
+
+  const gradeTitle = gradeDoc ? gradeDoc.title : requestTutor.grade || 'N/A';
+
+  const blocks = await Promise.all(
+    blockSubjectDocs.map(async ({ tutorBlock, subjectTitle, subjectDoc }) => {
+      const tutors = await Tutor.find(buildTutorMatchQuery(gradeDoc, subjectDoc, requestTutor, tutorBlock))
+        .populate('grades', 'title')
+        .populate('subjects', 'title')
+        .select(
+          'fullName contactNumber email tutorType tutorMediums preferredLocations yearsExperience highestEducation academicDetails teachingSummary studentResults sellingPoints language timeZone rate availability grades subjects'
+        )
+        .lean();
+
+      const matchedTutors = tutors
+        .map((tutor) => buildTutorSummary(tutor))
+        .sort((left, right) => {
+          if (right.availabilityCount !== left.availabilityCount) {
+            return right.availabilityCount - left.availabilityCount;
+          }
+
+          return (right.yearsExperience || 0) - (left.yearsExperience || 0);
+        });
+
+      return {
+        subject: subjectTitle,
+        preferredTutorType: tutorBlock.preferredTutorType,
+        preferredClassType: tutorBlock.preferredClassType,
+        duration: tutorBlock.duration,
+        frequency: tutorBlock.frequency,
+        matchedTutors,
+      };
+    })
+  );
+
+  const adminEmail = config.email.admin;
+  const requestSummary = {
+    name: requestTutor.name,
+    email: requestTutor.email,
+    phoneNumber: requestTutor.phoneNumber,
+    city: requestTutor.city,
+    district: requestTutor.district,
+    medium: requestTutor.medium,
+    grade: gradeTitle,
+    status: requestTutor.status,
+  };
+  const escapeHtml = (value) =>
+    String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
+  const escapeMultiline = (value) => escapeHtml(value).replace(/\n/g, '<br/>').replace(/\r/g, '');
+
+  const formatArrayCell = (values) => {
+    const items = Array.isArray(values) ? values : [];
+    return items.length ? items.map((item) => escapeHtml(item)).join('<br/>') : 'N/A';
+  };
+
+  const tutorRow = (tutor, index) => `
+    <tr>
+      <td>
+        <div class="tutor-name">${index + 1}. ${escapeHtml(tutor.fullName)}</div>
+        <div class="muted">${escapeHtml(tutor.rate || 'N/A')}</div>
+      </td>
+      <td>${escapeHtml(tutor.contactNumber || 'N/A')}</td>
+      <td>${escapeHtml(tutor.email || 'N/A')}</td>
+      <td>${formatArrayCell(tutor.tutorType)}</td>
+      <td>${formatArrayCell(tutor.tutorMediums)}</td>
+      <td>${escapeHtml(tutor.highestEducation || 'N/A')}</td>
+      <td>${escapeHtml(tutor.yearsExperience)}</td>
+      <td>${formatArrayCell(tutor.preferredLocations)}</td>
+      <td>${formatArrayCell(tutor.grades)}</td>
+      <td>${formatArrayCell(tutor.subjects)}</td>
+      <td>${formatArrayCell(tutor.availability)}</td>
+      <td>${escapeMultiline(tutor.academicDetails || 'N/A')}</td>
+      <td>${escapeMultiline(tutor.teachingSummary || 'N/A')}</td>
+      <td>${escapeMultiline(tutor.studentResults || 'N/A')}</td>
+      <td>${escapeMultiline(tutor.sellingPoints || 'N/A')}</td>
+      <td>${escapeHtml(tutor.language || 'N/A')}</td>
+      <td>${escapeHtml(tutor.timeZone || 'N/A')}</td>
+    </tr>
+  `;
+
+  const blockSection = (block, index) => `
+    <section class="block-card">
+      <div class="block-header">
+        <div>
+          <div class="eyebrow">Request Block ${index + 1}</div>
+          <h2>${escapeHtml(block.subject)}</h2>
+        </div>
+        <div class="pill">${block.matchedTutors.length} matched tutor(s)</div>
+      </div>
+      <div class="grid compact">
+        <div><span class="label">Preferred Tutor Type</span><div>${escapeHtml(block.preferredTutorType)}</div></div>
+        <div><span class="label">Preferred Class Type</span><div>${escapeHtml(block.preferredClassType)}</div></div>
+        <div><span class="label">Duration</span><div>${escapeHtml(block.duration)}</div></div>
+        <div><span class="label">Frequency</span><div>${escapeHtml(block.frequency)}</div></div>
+      </div>
+      ${
+        block.matchedTutors.length
+          ? `
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Tutor</th>
+                    <th>Contact</th>
+                    <th>Email</th>
+                    <th>Tutor Type</th>
+                    <th>Mediums</th>
+                    <th>Highest Education</th>
+                    <th>Experience</th>
+                    <th>Locations</th>
+                    <th>Grades</th>
+                    <th>Subjects</th>
+                    <th>Availability</th>
+                    <th>Academic Details</th>
+                    <th>Teaching Summary</th>
+                    <th>Student Results</th>
+                    <th>Selling Points</th>
+                    <th>Language</th>
+                    <th>Time Zone</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${block.matchedTutors.map((tutor, tutorIndex) => tutorRow(tutor, tutorIndex)).join('')}
+                </tbody>
+              </table>
+            </div>
+          `
+          : '<div class="empty-state">No tutors matched this block.</div>'
+      }
+    </section>
+  `;
+
+  const html = `
+    <div style="background:#f5f7fb;padding:32px 0;font-family:Arial,sans-serif;color:#111827;">
+      <style>
+        .report-shell { max-width: 1180px; margin: 0 auto; padding: 0 16px; }
+        .report-card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 18px; overflow: hidden; box-shadow: 0 10px 30px rgba(15,23,42,0.08); }
+        .report-header { background: linear-gradient(135deg,#111827,#334155); color: #fff; padding: 28px 32px; }
+        .report-header h1 { margin: 8px 0 0; font-size: 28px; line-height: 1.2; }
+        .report-body { padding: 28px 32px; background: #fff; }
+        .summary-grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(180px,1fr)); gap: 16px; margin-bottom: 28px; }
+        .block-card { border: 1px solid #e5e7eb; border-radius: 16px; padding: 20px; margin-top: 20px; background: #fafafa; }
+        .block-header { display:flex; justify-content:space-between; align-items:flex-start; gap: 16px; margin-bottom: 16px; }
+        .eyebrow { font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: #6b7280; }
+        .pill { background: #111827; color: #fff; border-radius: 999px; padding: 8px 12px; font-size: 12px; white-space: nowrap; }
+        .grid.compact { display: grid; grid-template-columns: repeat(auto-fit,minmax(160px,1fr)); gap: 12px; margin-bottom: 16px; }
+        .label { display:block; font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: #6b7280; margin-bottom: 4px; }
+        .muted { color: #6b7280; font-size: 12px; }
+        .empty-state { padding: 16px; background: #fff7ed; border: 1px solid #fed7aa; border-radius: 12px; color: #9a3412; }
+        .table-wrap { overflow-x: auto; margin-top: 16px; border: 1px solid #e5e7eb; border-radius: 14px; background: #fff; }
+        table { width: 100%; border-collapse: collapse; min-width: 1500px; }
+        thead th { background: #f8fafc; position: sticky; top: 0; z-index: 1; }
+        th, td { border-bottom: 1px solid #e5e7eb; padding: 12px 14px; vertical-align: top; text-align: left; font-size: 13px; line-height: 1.5; }
+        th { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #475569; }
+        tbody tr:nth-child(even) { background: #fcfcfd; }
+        .tutor-name { font-weight: 700; color: #111827; }
+      </style>
+      <div class="report-shell">
+        <div class="report-card">
+          <div class="report-header">
+            <div style="font-size:12px;letter-spacing:.12em;text-transform:uppercase;opacity:.8;">Tutor Request Match Report</div>
+            <h1 style="margin:8px 0 0;font-size:28px;line-height:1.2;">${escapeHtml(requestSummary.name)}</h1>
+            <p style="margin:10px 0 0;opacity:.85;">Automatically matched tutors based on request criteria and tutor profile availability.</p>
+          </div>
+          <div class="report-body">
+            <div class="summary-grid">
+              <div><div class="label">Request ID</div><div>${escapeHtml(requestTutor.id || requestTutor._id)}</div></div>
+              <div><div class="label">Requester Email</div><div>${escapeHtml(requestSummary.email)}</div></div>
+              <div><div class="label">Phone</div><div>${escapeHtml(requestSummary.phoneNumber)}</div></div>
+              <div><div class="label">Location</div><div>${escapeHtml(
+                `${requestSummary.city}, ${requestSummary.district}`
+              )}</div></div>
+              <div><div class="label">Medium</div><div>${escapeHtml(requestSummary.medium)}</div></div>
+              <div><div class="label">Grade</div><div>${escapeHtml(requestSummary.grade)}</div></div>
+            </div>
+
+            ${blocks.map((block, index) => blockSection(block, index)).join('')}
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const text = [
+    'Tutor Request Match Report',
+    `Request ID: ${requestTutor.id || requestTutor._id}`,
+    `Requester: ${requestSummary.name}`,
+    `Email: ${requestSummary.email}`,
+    `Phone: ${requestSummary.phoneNumber}`,
+    `Location: ${requestSummary.city}, ${requestSummary.district}`,
+    `Medium: ${requestSummary.medium}`,
+    `Grade: ${requestSummary.grade}`,
+    `Status: ${requestSummary.status}`,
+  ].join('\n');
+
+  return {
+    adminEmail,
+    requestSummary,
+    blocks,
+    text,
+    html,
+  };
+};
+
 const sendAcknowledgement = async (requestTutorBody) => {
   try {
     await emailService.sendAcknowledgement(requestTutorBody);
@@ -191,6 +503,29 @@ const queryTutorsRequests = async (filter, options) => {
  */
 const getRequestTutorById = async (id) => {
   return RequestTutor.findById(id);
+};
+
+const sendTutorMatchReportToAdmin = async (requestTutorId) => {
+  const requestTutorDoc = await getRequestTutorById(requestTutorId);
+
+  if (!requestTutorDoc) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Tutor request not found');
+  }
+
+  const report = await buildTutorRequestMatchReport(requestTutorDoc);
+  const subject = `Tutor Request Match Report - ${report.requestSummary.name}`;
+
+  await emailService.sendEmail(report.adminEmail, subject, report.text, report.html);
+
+  return {
+    message: 'Tutor request match report sent to admin',
+    adminEmail: report.adminEmail,
+    requestTutorId: requestTutorDoc.id,
+    matchedBlocks: report.blocks.map((block) => ({
+      subject: block.subject,
+      matchedTutors: block.matchedTutors.length,
+    })),
+  };
 };
 
 /**
@@ -287,4 +622,5 @@ module.exports = {
   deleteTutorRequestById,
   updateStatusById,
   updateAssignedTutor,
+  sendTutorMatchReportToAdmin,
 };

--- a/src/services/requestTutor.service.js
+++ b/src/services/requestTutor.service.js
@@ -4,6 +4,127 @@ const ApiError = require('../utils/ApiError');
 const emailService = require('./email.service');
 const logger = require('../config/logger');
 
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const toArray = (value) => (Array.isArray(value) ? value : [value]);
+const normalizeValues = (value) =>
+  toArray(value)
+    .map((item) => String(item).trim())
+    .filter(Boolean);
+
+const buildExactMatch = (value) => ({
+  $regex: `^${escapeRegex(String(value).trim())}$`,
+  $options: 'i',
+});
+
+const buildContainsMatch = (value) => ({
+  $regex: escapeRegex(String(value).trim()),
+  $options: 'i',
+});
+
+const buildScalarFilter = (value, { contains = false } = {}) => {
+  if (Array.isArray(value)) {
+    return { $in: normalizeValues(value) };
+  }
+
+  return contains ? buildContainsMatch(value) : buildExactMatch(value);
+};
+
+const buildTutorRequestQuery = (filter = {}) => {
+  const query = { ...filter };
+  const searchTerm = typeof query.search === 'string' ? query.search.trim() : '';
+
+  delete query.search;
+
+  if (query.name) {
+    query.name = buildScalarFilter(query.name, { contains: true });
+  }
+
+  if (query.email) {
+    query.email = buildScalarFilter(query.email);
+  }
+
+  if (query.phoneNumber) {
+    query.phoneNumber = buildScalarFilter(query.phoneNumber, { contains: true });
+  }
+
+  if (query.city) {
+    query.city = buildScalarFilter(query.city);
+  }
+
+  if (query.district) {
+    query.district = buildScalarFilter(query.district);
+  }
+
+  if (query.grade) {
+    query.grade = buildScalarFilter(query.grade);
+  }
+
+  if (query.medium) {
+    query.medium = buildScalarFilter(query.medium);
+  }
+
+  if (query.status) {
+    query.status = buildScalarFilter(query.status);
+  }
+
+  const tutorBlockFilters = {};
+
+  if (query.subject) {
+    tutorBlockFilters.subject = buildScalarFilter(query.subject, { contains: true });
+    delete query.subject;
+  }
+
+  if (query.assignedTutor) {
+    tutorBlockFilters.assignedTutor = buildScalarFilter(query.assignedTutor, { contains: true });
+    delete query.assignedTutor;
+  }
+
+  if (query.preferredTutorType) {
+    tutorBlockFilters.preferredTutorType = Array.isArray(query.preferredTutorType)
+      ? { $in: toArray(query.preferredTutorType).map((value) => String(value).trim()) }
+      : buildExactMatch(query.preferredTutorType);
+    delete query.preferredTutorType;
+  }
+
+  if (query.preferredClassType) {
+    tutorBlockFilters.preferredClassType = Array.isArray(query.preferredClassType)
+      ? { $in: toArray(query.preferredClassType).map((value) => String(value).trim()) }
+      : buildExactMatch(query.preferredClassType);
+    delete query.preferredClassType;
+  }
+
+  if (query.duration) {
+    tutorBlockFilters.duration = Array.isArray(query.duration)
+      ? { $in: toArray(query.duration).map((value) => String(value).trim()) }
+      : buildExactMatch(query.duration);
+    delete query.duration;
+  }
+
+  if (query.frequency) {
+    tutorBlockFilters.frequency = Array.isArray(query.frequency)
+      ? { $in: toArray(query.frequency).map((value) => String(value).trim()) }
+      : buildExactMatch(query.frequency);
+    delete query.frequency;
+  }
+
+  if (Object.keys(tutorBlockFilters).length > 0) {
+    query.tutors = { $elemMatch: tutorBlockFilters };
+  }
+
+  if (searchTerm) {
+    const searchRegex = buildContainsMatch(searchTerm);
+    query.$or = [
+      { name: searchRegex },
+      { email: searchRegex },
+      { phoneNumber: searchRegex },
+      { city: searchRegex },
+      { district: searchRegex },
+    ];
+  }
+
+  return query;
+};
+
 const sendAcknowledgement = async (requestTutorBody) => {
   try {
     await emailService.sendAcknowledgement(requestTutorBody);
@@ -45,7 +166,10 @@ const sendAssignmentEmails = async (tutorRequest, assignedBlock) => {
 const requestTutor = async (requestTutorBody) => {
   logger.info({ requestTutorBody }, 'Tutor request created');
 
-  const tutorCreateResponse = await RequestTutor.create(requestTutorBody);
+  const tutorCreateResponse = await RequestTutor.create({
+    ...requestTutorBody,
+    status: 'Pending',
+  });
   if (tutorCreateResponse) {
     sendAcknowledgement(requestTutorBody);
   }
@@ -56,7 +180,7 @@ const requestTutor = async (requestTutorBody) => {
  * Query for tutor requests
  */
 const queryTutorsRequests = async (filter, options) => {
-  const requestTutors = await RequestTutor.paginate(filter, {
+  const requestTutors = await RequestTutor.paginate(buildTutorRequestQuery(filter), {
     ...options,
   });
   return requestTutors;
@@ -84,14 +208,24 @@ const deleteTutorRequestById = async (requestTutorId) => {
 /**
  * Update ONLY the status
  */
-const updateStatusById = async (requestTutorId, status) => {
+const updateStatusById = async (requestTutorId, status, rejectionReason) => {
   const tutorRequest = await getRequestTutorById(requestTutorId);
   if (!tutorRequest) {
     throw new ApiError(httpStatus.NOT_FOUND, 'Tutor request not found');
   }
 
+  const previousStatus = tutorRequest.status;
   tutorRequest.status = status;
   await tutorRequest.save();
+
+  if (status === 'Rejected' && previousStatus !== 'Rejected') {
+    try {
+      await emailService.sendRequestTutorRejectedEmail(tutorRequest.email, tutorRequest.name, rejectionReason, tutorRequest);
+    } catch (err) {
+      logger.error({ err }, 'Failed to send tutor request rejection email');
+    }
+  }
+
   return tutorRequest;
 };
 

--- a/src/validations/requestTutor.validation.js
+++ b/src/validations/requestTutor.validation.js
@@ -38,13 +38,9 @@ const createRequestTutor = {
         'any.only': 'Medium must be one of the allowed values',
         'any.required': 'Medium is required',
       }),
-    status: Joi.string()
-      .valid(...requestTutorStatuses)
-      .required()
-      .messages({
-        'any.only': 'Status must be one of the allowed values',
-        'any.required': 'Status is required',
-      }),
+    status: Joi.string().valid('Pending').default('Pending').messages({
+      'any.only': 'Status must be Pending',
+    }),
     grade: Joi.string().trim().required().messages({
       'string.empty': 'Grade is required',
       'any.required': 'Grade is required',
@@ -98,7 +94,39 @@ const createRequestTutor = {
 
 const getTutors = {
   query: Joi.object().keys({
-    name: Joi.string(),
+    search: Joi.string(),
+    name: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
+    email: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
+    city: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
+    district: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
+    grade: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
+    medium: Joi.alternatives().try(
+      Joi.string().valid(...tutorMediums),
+      Joi.array().items(Joi.string().valid(...tutorMediums))
+    ),
+    status: Joi.alternatives().try(
+      Joi.string().valid(...requestTutorStatuses),
+      Joi.array().items(Joi.string().valid(...requestTutorStatuses))
+    ),
+    phoneNumber: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
+    subject: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
+    assignedTutor: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
+    preferredTutorType: Joi.alternatives().try(
+      Joi.string().valid(...tutorTypes),
+      Joi.array().items(Joi.string().valid(...tutorTypes))
+    ),
+    preferredClassType: Joi.alternatives().try(
+      Joi.string().valid(...requestTutorClassTypes),
+      Joi.array().items(Joi.string().valid(...requestTutorClassTypes))
+    ),
+    duration: Joi.alternatives().try(
+      Joi.string().valid(...sessionDurations),
+      Joi.array().items(Joi.string().valid(...sessionDurations))
+    ),
+    frequency: Joi.alternatives().try(
+      Joi.string().valid(...sessionFrequencies),
+      Joi.array().items(Joi.string().valid(...sessionFrequencies))
+    ),
     sortBy: Joi.string(),
     limit: Joi.number().integer(),
     page: Joi.number().integer(),
@@ -135,6 +163,16 @@ const updateStatus = {
       .messages({
         'any.only': 'Status must be one of the allowed values',
         'any.required': 'Status is required',
+      }),
+    rejectionReason: Joi.string()
+      .trim()
+      .when('status', {
+        is: 'Rejected',
+        then: Joi.required().messages({
+          'string.empty': 'Rejection reason is required when rejecting a tutor request',
+          'any.required': 'Rejection reason is required when rejecting a tutor request',
+        }),
+        otherwise: Joi.optional().allow('', null),
       }),
   }),
 };

--- a/src/validations/requestTutor.validation.js
+++ b/src/validations/requestTutor.validation.js
@@ -207,6 +207,19 @@ const updateAssignedTutor = {
   }),
 };
 
+const sendTutorMatchReport = {
+  params: Joi.object().keys({
+    requestTutorId: Joi.string()
+      .custom((value, helpers) => {
+        if (!mongoose.Types.ObjectId.isValid(value)) {
+          return helpers.message('Invalid request tutor ID');
+        }
+        return value;
+      })
+      .required(),
+  }),
+};
+
 module.exports = {
   createRequestTutor,
   getTutors,
@@ -214,4 +227,5 @@ module.exports = {
   deleteTutor,
   updateStatus,
   updateAssignedTutor,
+  sendTutorMatchReport,
 };


### PR DESCRIPTION
## Summary

This PR improves the `Request Tutor` backend flow and admin reporting.

### What changed

- Added backend filtering for tutor requests.
- Restricted tutor request statuses to:
  - `Pending`
  - `Rejected`
- New tutor requests now default to `Pending`.
- Added rejection reason support when an admin marks a request as `Rejected`.
- Sends a custom rejection email to the requester with the provided reason.
- Added a new admin-only API to generate a tutor match report for a request.
- The tutor match report now:
  - matches tutors by `medium`, `grade`, `subject`, `tutor type`, and `class type`
  - resolves request grades/subjects to the correct reference records
  - includes each tutor’s full profile details
  - includes availability slots from the tutor profile
  - sends the result to the admin email
- Upgraded the match report email to a clear HTML layout with a table of matched tutors.

### New API

- `POST /v1/requestTutor/match-tutors/:requestTutorId`

### Report includes

- Request summary
- Matched tutors per block
- Tutor details:
  - full name
  - contact number
  - email
  - tutor type
  - tutor mediums
  - preferred locations
  - years of experience
  - highest education
  - academic details
  - teaching summary
  - student results
  - selling points
  - language
  - time zone
  - rate
  - grades
  - subjects
  - availability

### Config updates

- Added `ADMIN_EMAIL` support in config
- Falls back to `EMAIL_FROM` if `ADMIN_EMAIL` is not provided

### Screenshots
<img width="1898" height="972" alt="image" src="https://github.com/user-attachments/assets/e7f2cb85-e208-4213-8582-8aaf5b376d7d" />
<img width="1902" height="915" alt="image" src="https://github.com/user-attachments/assets/ac3e1ad4-bd92-49b6-995d-9e8e3b1b9a71" />

