### PR TITLE
fix: correct Reset Password button alignment in email template [TM-876]

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -59,7 +59,7 @@ If you didn’t request this, please ignore this email.
         <p>Hello,</p>
         <p>We received a request to reset the password for your <strong>TuitionLanka</strong> account.</p>
         <p>You can reset your password by clicking the button below:</p>
-        <p style="text-align: center; margin: 25px 0;">
+        <p style="text-align: left; margin: 25px 0;">
           <a href="${resetPasswordUrl}"
              style="background-color: #4F46E5; color: #fff; padding: 12px 24px;
                     border-radius: 8px; text-decoration: none; font-weight: bold;">


### PR DESCRIPTION
## Summary
- Fixed "Reset Password" button alignment in the password reset email template
- Button was center-aligned due to `text-align: center` on the wrapping `<p>` tag
- Changed to `text-align: left` to align with the rest of the email content

## Root Cause
`email.service.js` → `sendResetPasswordEmail()` — the `<p>` wrapping the button had an inline `text-align: center` style applied.

## Files Changed
- `src/services/email.service.js`

## Test Plan
- [ ] Trigger a forgot password flow from the client portal
- [ ] Verify the "Reset Password" button appears left-aligned in the received email
- [ ] Verify the button link still works correctly