### PR TITLE
TM-930: Add portal-aware reset password links for admin and user portals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,4 +24,6 @@ SMTP_USERNAME=email-server-username
 SMTP_PASSWORD=email-server-password
 EMAIL_FROM=support@yourapp.com
 ADMIN_EMAIL=admin@yourapp.com
+USER_APP_URL=https://www.tuitionlanka.com
+ADMIN_APP_URL=https://admin.tuitionlanka.com
 #config proper email server

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -24,6 +24,8 @@ const envVarsSchema = Joi.object()
     SMTP_PASSWORD: Joi.string().description('password for email server'),
     EMAIL_FROM: Joi.string().description('the from field in the emails sent by the app'),
     ADMIN_EMAIL: Joi.string().email().description('the admin email that receives tutor request match reports'),
+    USER_APP_URL: Joi.string().uri().description('the user portal base url'),
+    ADMIN_APP_URL: Joi.string().uri().description('the admin portal base url'),
   })
   .unknown();
 
@@ -67,5 +69,9 @@ module.exports = {
     },
     from: `"Tuition Lanka" <${process.env.EMAIL_FROM}>`,
     admin: envVars.ADMIN_EMAIL || envVars.EMAIL_FROM,
+  },
+  app: {
+    userUrl: envVars.USER_APP_URL || 'https://www.tuitionlanka.com',
+    adminUrl: envVars.ADMIN_APP_URL || 'https://admin.tuitionlanka.com',
   },
 };

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,6 +1,36 @@
 const httpStatus = require('http-status');
 const catchAsync = require('../utils/catchAsync');
+const config = require('../config/config');
 const { authService, userService, tokenService, emailService } = require('../services');
+
+const resolveResetPasswordAppUrl = (req) => {
+  const { portal } = req.body;
+  const origin = req.get('origin') || req.get('referer');
+
+  if (portal === 'admin') {
+    return config.app.adminUrl;
+  }
+
+  if (portal === 'user') {
+    return config.app.userUrl;
+  }
+
+  if (origin) {
+    try {
+      const originUrl = new URL(origin).origin;
+      if (originUrl === new URL(config.app.adminUrl).origin) {
+        return config.app.adminUrl;
+      }
+      if (originUrl === new URL(config.app.userUrl).origin) {
+        return config.app.userUrl;
+      }
+    } catch (err) {
+      // Ignore malformed origins and fall back to the user portal.
+    }
+  }
+
+  return config.app.userUrl;
+};
 
 const register = catchAsync(async (req, res) => {
   const user = await userService.createUser(req.body);
@@ -31,7 +61,8 @@ const refreshTokens = catchAsync(async (req, res) => {
 
 const forgotPassword = catchAsync(async (req, res) => {
   const resetPasswordToken = await tokenService.generateResetPasswordToken(req.body.email);
-  await emailService.sendResetPasswordEmail(req.body.email, resetPasswordToken);
+  const appUrl = resolveResetPasswordAppUrl(req);
+  await emailService.sendResetPasswordEmail(req.body.email, resetPasswordToken, appUrl);
   res.status(httpStatus.NO_CONTENT).send();
 });
 

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -24,6 +24,8 @@ const sendEmail = async (to, subject, text, html) => {
   await transport.sendMail(msg);
 };
 
+const normalizeBaseUrl = (url) => String(url || '').replace(/\/+$/, '');
+
 const escapeHtml = (value) =>
   String(value)
     .replace(/&/g, '&amp;')
@@ -51,10 +53,10 @@ const resolveGradeName = async (gradeValue) => {
  * @param {string} token
  * @returns {Promise}
  */
-const sendResetPasswordEmail = async (to, token) => {
+const sendResetPasswordEmail = async (to, token, appUrl = config.app.userUrl) => {
   try {
     const subject = 'Reset Your TuitionLanka Password';
-    const resetPasswordUrl = `https://tuitionlanka.com/reset-password?token=${token}`;
+    const resetPasswordUrl = `${normalizeBaseUrl(appUrl)}/reset-password?token=${token}`;
 
     const text = `
 Hello,

--- a/src/validations/auth.validation.js
+++ b/src/validations/auth.validation.js
@@ -31,6 +31,7 @@ const refreshTokens = {
 const forgotPassword = {
   body: Joi.object().keys({
     email: Joi.string().email().required(),
+    portal: Joi.string().valid('admin', 'user'),
   }),
 };
 

--- a/tests/integration/auth.test.js
+++ b/tests/integration/auth.test.js
@@ -239,13 +239,28 @@ describe('Auth routes', () => {
       jest.spyOn(emailService.transport, 'sendMail').mockResolvedValue();
     });
 
-    test('should return 204 and send reset password email to the user', async () => {
+    test('should return 204 and send reset password email to the user portal by default', async () => {
       await insertUsers([userOne]);
       const sendResetPasswordEmailSpy = jest.spyOn(emailService, 'sendResetPasswordEmail');
 
       await request(app).post('/v1/auth/forgot-password').send({ email: userOne.email }).expect(httpStatus.NO_CONTENT);
 
-      expect(sendResetPasswordEmailSpy).toHaveBeenCalledWith(userOne.email, expect.any(String));
+      expect(sendResetPasswordEmailSpy).toHaveBeenCalledWith(userOne.email, expect.any(String), config.app.userUrl);
+      const resetPasswordToken = sendResetPasswordEmailSpy.mock.calls[0][1];
+      const dbResetPasswordTokenDoc = await Token.findOne({ token: resetPasswordToken, user: userOne._id });
+      expect(dbResetPasswordTokenDoc).toBeDefined();
+    });
+
+    test('should return 204 and send reset password email to the admin portal when requested', async () => {
+      await insertUsers([userOne]);
+      const sendResetPasswordEmailSpy = jest.spyOn(emailService, 'sendResetPasswordEmail');
+
+      await request(app)
+        .post('/v1/auth/forgot-password')
+        .send({ email: userOne.email, portal: 'admin' })
+        .expect(httpStatus.NO_CONTENT);
+
+      expect(sendResetPasswordEmailSpy).toHaveBeenCalledWith(userOne.email, expect.any(String), config.app.adminUrl);
       const resetPasswordToken = sendResetPasswordEmailSpy.mock.calls[0][1];
       const dbResetPasswordTokenDoc = await Token.findOne({ token: resetPasswordToken, user: userOne._id });
       expect(dbResetPasswordTokenDoc).toBeDefined();


### PR DESCRIPTION
## Summary
Add portal-aware password reset links so the forgot-password flow sends users back to the correct frontend:
- Admin portal: `https://admin.tuitionlanka.com`
- User portal: `https://www.tuitionlanka.com`

## What Changed
- Added configurable portal base URLs in `config`
- Updated reset password email generation to build links from the selected portal URL
- Updated `forgot-password` to accept an optional `portal` value
- Added safe portal resolution with fallback behavior
- Added/updated integration coverage for:
  - default user portal reset links
  - admin portal reset links

## Behavior
- `portal: "admin"` sends a reset link with the admin portal
- `portal: "user"` sends a reset link with the user portal
- If `portal` is omitted, the backend falls back to the user portal
- The API also checks `Origin` / `Referer` as a secondary fallback

## API Example
```json
POST /v1/auth/forgot-password
{
  "email": "user@example.com",
  "portal": "admin"
}
```
## Screenshots
### Admin
<img width="1643" height="913" alt="image" src="https://github.com/user-attachments/assets/fd0b46a7-cbd3-4dcf-a6d2-ca4ae6def0ef" />

### User
<img width="1626" height="903" alt="image" src="https://github.com/user-attachments/assets/f0e377db-d0d6-4728-b3d4-cb68357bd4cf" />
