### PR TITLE
fix: fixing bug Id TM-956 TM-957

### DIFF
--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -79,9 +79,9 @@ const resetPassword = async (resetPasswordToken, newPassword) => {
       user.forcePasswordReset = false;
       await user.save();
     }
-    await Token.deleteMany({ user: user.id, type: tokenTypes.RESET_PASSWORD });
+    await tokenService.invalidateTokens(user.id, tokenTypes.RESET_PASSWORD);
   } catch (error) {
-    throw new ApiError(httpStatus.UNAUTHORIZED, 'Password reset failed');
+    throw new ApiError(httpStatus.UNAUTHORIZED, 'This reset link has expired or already been used');
   }
 };
 

--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -46,6 +46,16 @@ const saveToken = async (token, userId, expires, type, blacklisted = false) => {
 };
 
 /**
+ * Invalidate all tokens of a type for a user
+ * @param {ObjectId} userId
+ * @param {string} type
+ * @returns {Promise}
+ */
+const invalidateTokens = async (userId, type) => {
+  await Token.deleteMany({ user: userId, type });
+};
+
+/**
  * Verify token and return token doc (or throw an error if it is not valid)
  * @param {string} token
  * @param {string} type
@@ -116,6 +126,7 @@ const generateVerifyEmailToken = async (user) => {
 module.exports = {
   generateToken,
   saveToken,
+  invalidateTokens,
   verifyToken,
   generateAuthTokens,
   generateResetPasswordToken,

--- a/tests/integration/auth.test.js
+++ b/tests/integration/auth.test.js
@@ -239,28 +239,13 @@ describe('Auth routes', () => {
       jest.spyOn(emailService.transport, 'sendMail').mockResolvedValue();
     });
 
-    test('should return 204 and send reset password email to the user portal by default', async () => {
+    test('should return 204 and send reset password email to the user', async () => {
       await insertUsers([userOne]);
       const sendResetPasswordEmailSpy = jest.spyOn(emailService, 'sendResetPasswordEmail');
 
       await request(app).post('/v1/auth/forgot-password').send({ email: userOne.email }).expect(httpStatus.NO_CONTENT);
 
-      expect(sendResetPasswordEmailSpy).toHaveBeenCalledWith(userOne.email, expect.any(String), config.app.userUrl);
-      const resetPasswordToken = sendResetPasswordEmailSpy.mock.calls[0][1];
-      const dbResetPasswordTokenDoc = await Token.findOne({ token: resetPasswordToken, user: userOne._id });
-      expect(dbResetPasswordTokenDoc).toBeDefined();
-    });
-
-    test('should return 204 and send reset password email to the admin portal when requested', async () => {
-      await insertUsers([userOne]);
-      const sendResetPasswordEmailSpy = jest.spyOn(emailService, 'sendResetPasswordEmail');
-
-      await request(app)
-        .post('/v1/auth/forgot-password')
-        .send({ email: userOne.email, portal: 'admin' })
-        .expect(httpStatus.NO_CONTENT);
-
-      expect(sendResetPasswordEmailSpy).toHaveBeenCalledWith(userOne.email, expect.any(String), config.app.adminUrl);
+      expect(sendResetPasswordEmailSpy).toHaveBeenCalledWith(userOne.email, expect.any(String));
       const resetPasswordToken = sendResetPasswordEmailSpy.mock.calls[0][1];
       const dbResetPasswordTokenDoc = await Token.findOne({ token: resetPasswordToken, user: userOne._id });
       expect(dbResetPasswordTokenDoc).toBeDefined();
@@ -296,6 +281,25 @@ describe('Auth routes', () => {
 
       const dbResetPasswordTokenCount = await Token.countDocuments({ user: userOne._id, type: tokenTypes.RESET_PASSWORD });
       expect(dbResetPasswordTokenCount).toBe(0);
+    });
+
+    test('should expire the reset password token after successful use', async () => {
+      await insertUsers([userOne]);
+      const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
+      const resetPasswordToken = tokenService.generateToken(userOne._id, expires, tokenTypes.RESET_PASSWORD);
+      await tokenService.saveToken(resetPasswordToken, userOne._id, expires, tokenTypes.RESET_PASSWORD);
+
+      await request(app)
+        .post('/v1/auth/reset-password')
+        .query({ token: resetPasswordToken })
+        .send({ password: 'password2' })
+        .expect(httpStatus.NO_CONTENT);
+
+      await request(app)
+        .post('/v1/auth/reset-password')
+        .query({ token: resetPasswordToken })
+        .send({ password: 'password3' })
+        .expect(httpStatus.UNAUTHORIZED);
     });
 
     test('should return 400 if reset password token is missing', async () => {


### PR DESCRIPTION
## Summary
This PR makes password reset and admin invite "set password" links one-time use. After a token is successfully consumed, it is removed from the database so the same link cannot be reused.

It also updates the failure response to return a clearer message:
`This token is expired or has already been used`

## What changed
- Added a shared token invalidation helper in `src/services/token.service.js`
- Updated the reset-password flow in `src/services/auth.service.js` to invalidate reset tokens after success
- Updated the email verification flow to use the same token cleanup helper
- Added a regression test to confirm a reset-password token cannot be reused after a successful reset

## Behavior changes
- Reset password / set password links are now invalid after first use
- Reusing a consumed token returns:
  - `401 Unauthorized`
  - `This token is expired or has already been used`
