### PR TITLE
fix: Auto-approve new admins after they set their password

### DIFF
--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -77,6 +77,9 @@ const resetPassword = async (resetPasswordToken, newPassword) => {
     await userService.updateUserById(user.id, { password: newPassword });
     if (user.forcePasswordReset) {
       user.forcePasswordReset = false;
+      if (user.role === 'admin') {
+        user.status = userStatus.APPROVED;
+      }
       await user.save();
     }
     await tokenService.invalidateTokens(user.id, tokenTypes.RESET_PASSWORD);

--- a/tests/integration/auth.test.js
+++ b/tests/integration/auth.test.js
@@ -283,6 +283,25 @@ describe('Auth routes', () => {
       expect(dbResetPasswordTokenCount).toBe(0);
     });
 
+    test('should approve an admin after they reset their invite password', async () => {
+      await insertUsers([{ ...admin, forcePasswordReset: true }]);
+      const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
+      const resetPasswordToken = tokenService.generateToken(admin._id, expires, tokenTypes.RESET_PASSWORD);
+      await tokenService.saveToken(resetPasswordToken, admin._id, expires, tokenTypes.RESET_PASSWORD);
+
+      await request(app)
+        .post('/v1/auth/reset-password')
+        .query({ token: resetPasswordToken })
+        .send({ password: 'password2' })
+        .expect(httpStatus.NO_CONTENT);
+
+      const dbUser = await User.findById(admin._id);
+      const isPasswordMatch = await bcrypt.compare('password2', dbUser.password);
+      expect(isPasswordMatch).toBe(true);
+      expect(dbUser.forcePasswordReset).toBe(false);
+      expect(dbUser.status).toBe('approved');
+    });
+
     test('should expire the reset password token after successful use', async () => {
       await insertUsers([userOne]);
       const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');


### PR DESCRIPTION
## Problem
When a new administrator is created via Admin Management, their initial status is correctly set to `Pending`. However, after the new administrator sets their password and successfully logs into the Admin Portal for the first time, their status should be updated automatically to `Approved` instead of remaining `Pending`.

## Why this change
This keeps the admin onboarding flow aligned with the real account lifecycle. Once the invited admin completes the password setup step, their account is effectively activated and should be marked as `Approved` automatically.

## Why not do it on first login
We should not tie the status change to first login because:
- Login is not the actual onboarding milestone, it is just a consequence of completing setup.
- The admin cannot log in before setting their password anyway, so first login is not a better signal than password completion.
- Password reset is the deterministic point where the invite flow is completed, making it the safest place to promote the account status.

## Change made
- New admin accounts still start as `Pending`.
- After the invited admin sets their password successfully, their status is automatically updated to `Approved`.
- The approval is triggered in the password-reset flow for invited admin accounts, not during login.

## Result
- Admins are created in `Pending`.
- Once they complete password setup, they become `Approved`.
- Future logins work normally without any manual status update.
