### PR TITLE
feat(TM-966): add tutor unassignment endpoint for admin panel

### DIFF
--- a/src/controllers/requestTutor.controllers.js
+++ b/src/controllers/requestTutor.controllers.js
@@ -69,6 +69,13 @@ const sendTutorMatchReport = catchAsync(async (req, res) => {
   res.send(result);
 });
 
+const unassignTutor = catchAsync(async (req, res) => {
+  const { requestTutorId } = req.params;
+  const { tutorBlockIds, unassignReason } = req.body;
+  const updated = await requestTutorService.unassignTutor(requestTutorId, tutorBlockIds, unassignReason);
+  res.send(updated);
+});
+
 module.exports = {
   createTutorRequest,
   getTutorRequests,
@@ -76,5 +83,6 @@ module.exports = {
   deleteTutor,
   updateStatus,
   updateAssignedTutor,
+  unassignTutor,
   sendTutorMatchReport,
 };

--- a/src/routes/v1/request-tutor.route.js
+++ b/src/routes/v1/request-tutor.route.js
@@ -29,6 +29,10 @@ router
   );
 
 router
+  .route('/unassign/:requestTutorId')
+  .patch(auth('manageUsers'), validate(requestTutorValidation.unassignTutor), requestTutorController.unassignTutor);
+
+router
   .route('/match-tutors/:requestTutorId')
   .post(
     auth('manageUsers'),

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -954,6 +954,73 @@ Tuition Lanka – Learn Better, Achieve More
   }
 };
 
+/**
+ * Send tutor unassignment notification email to the requester
+ * @param {Object} tutorRequest
+ * @param {Array}  unassignedBlocks  - [{ subjectName, tutorName }]
+ * @param {string} unassignReason
+ */
+const sendTutorUnassignedToRequester = async (tutorRequest, unassignedBlocks, unassignReason) => {
+  try {
+    const { name, email } = tutorRequest;
+    const subject = 'Update on Your Tuition Request – Tuition Lanka';
+
+    const blockLines = unassignedBlocks
+      .map((b) => `  - ${b.subjectName} (previously assigned to ${b.tutorName})`)
+      .join('\n');
+
+    const blockHtml = unassignedBlocks
+      .map(
+        (b) => `<li><strong>${escapeHtml(b.subjectName)}</strong> — previously assigned to ${escapeHtml(b.tutorName)}</li>`
+      )
+      .join('');
+
+    const text = `
+Dear ${name},
+
+We wanted to let you know that the tutor previously assigned to your tuition request has been unassigned.
+
+Affected Subject(s):
+${blockLines}
+
+Reason: ${unassignReason}
+
+Our team is already working on finding a suitable replacement and will be in touch with you shortly.
+
+If you have any questions, please don't hesitate to contact us.
+
+Warm regards,
+Tuition Lanka Team
+Tuition Lanka – Learn Better, Achieve More
+`;
+
+    const html = `
+      <div style="font-family: Arial, sans-serif; color:#222; line-height:1.6">
+        <p>Dear <strong>${escapeHtml(name)}</strong>,</p>
+        <p>We wanted to let you know that the tutor previously assigned to your tuition request has been <strong>unassigned</strong>.</p>
+
+        <h3>📋 Affected Subject(s)</h3>
+        <ul>${blockHtml}</ul>
+
+        <h3>📝 Reason</h3>
+        <p>${escapeHtml(unassignReason)}</p>
+
+        <p>Our team is already working on finding a suitable replacement and will be in touch with you shortly.</p>
+        <p>If you have any questions, please don't hesitate to contact us.</p>
+
+        <p>Warm regards,<br/>
+        <strong>Tuition Lanka Team</strong><br/>
+        Tuition Lanka – Learn Better, Achieve More</p>
+      </div>
+    `;
+
+    await transport.sendMail({ from: config.email.from, to: email, subject, text, html });
+    logger.info(`Tutor unassigned email sent to requester: ${email}`);
+  } catch (err) {
+    logger.error('Failed to send tutor unassigned email to requester:', err);
+  }
+};
+
 module.exports = {
   transport,
   sendEmail,
@@ -964,6 +1031,7 @@ module.exports = {
   sendRequestTutorRejectedEmail,
   sendTutorAssignedToRequester,
   sendTutorAssignedToTutor,
+  sendTutorUnassignedToRequester,
   sendTutorRegistrationPendingEmail,
   sendTutorApprovedEmail,
   sendTutorRejectedEmail,

--- a/src/services/requestTutor.service.js
+++ b/src/services/requestTutor.service.js
@@ -568,6 +568,57 @@ const deleteTutorRequestById = async (requestTutorId) => {
 };
 
 /**
+ * Unassign tutor(s) from specific blocks within a request.
+ * Reverts overall status to Pending if all blocks become unassigned.
+ * Fires an email to the requester with the reason (non-blocking).
+ */
+const unassignTutor = async (requestTutorId, tutorBlockIds, unassignReason) => {
+  const tutorRequest = await getRequestTutorById(requestTutorId);
+  if (!tutorRequest) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Tutor request not found');
+  }
+
+  // Capture block details before clearing so the email has accurate info
+  const blocksToNotify = await Promise.all(
+    tutorBlockIds.map(async (blockId) => {
+      const block = tutorRequest.tutors.id(blockId);
+      if (!block) return null;
+
+      const [subjectDoc, tutorDoc] = await Promise.all([
+        resolveSubjectDoc(block.subject),
+        block.assignedTutor ? Tutor.findById(block.assignedTutor).select('fullName').lean() : null,
+      ]);
+
+      return {
+        subjectName: subjectDoc ? subjectDoc.title : block.subject || 'N/A',
+        tutorName: tutorDoc ? tutorDoc.fullName : 'N/A',
+      };
+    })
+  ).then((results) => results.filter(Boolean));
+
+  tutorBlockIds.forEach((blockId) => {
+    const block = tutorRequest.tutors.id(blockId);
+    if (block) {
+      block.assignedTutor = null;
+    }
+  });
+
+  const allUnassigned = tutorRequest.tutors.every((block) => !block.assignedTutor);
+  if (allUnassigned) {
+    tutorRequest.status = 'Pending';
+  }
+
+  await tutorRequest.save();
+
+  // Fire email non-blocking
+  emailService.sendTutorUnassignedToRequester(tutorRequest, blocksToNotify, unassignReason).catch((err) => {
+    logger.warn(`Unassign email failed for request ${requestTutorId}: ${err.message}`);
+  });
+
+  return tutorRequest;
+};
+
+/**
  * Update ONLY the status
  */
 const updateStatusById = async (requestTutorId, status, rejectionReason) => {
@@ -650,5 +701,6 @@ module.exports = {
   deleteTutorRequestById,
   updateStatusById,
   updateAssignedTutor,
+  unassignTutor,
   sendTutorMatchReportToAdmin,
 };

--- a/src/validations/requestTutor.validation.js
+++ b/src/validations/requestTutor.validation.js
@@ -206,6 +206,29 @@ const sendTutorMatchReport = {
   }),
 };
 
+const unassignTutor = {
+  params: Joi.object().keys({
+    requestTutorId: Joi.string()
+      .custom((value, helpers) => {
+        if (!mongoose.Types.ObjectId.isValid(value)) {
+          return helpers.message('Invalid request tutor ID');
+        }
+        return value;
+      })
+      .required(),
+  }),
+  body: Joi.object().keys({
+    tutorBlockIds: Joi.array().items(Joi.string().trim()).min(1).required().messages({
+      'array.min': 'At least one tutor block ID is required',
+      'any.required': 'tutorBlockIds is required',
+    }),
+    unassignReason: Joi.string().trim().min(1).required().messages({
+      'string.empty': 'Reason for unassignment is required',
+      'any.required': 'Reason for unassignment is required',
+    }),
+  }),
+};
+
 module.exports = {
   createRequestTutor,
   getTutors,
@@ -214,4 +237,5 @@ module.exports = {
   updateStatus,
   updateAssignedTutor,
   sendTutorMatchReport,
+  unassignTutor,
 };


### PR DESCRIPTION
Ticket: https://softvilmedia-team.atlassian.net/browse/TM-966

Summary: Implemented the backend endpoint to allow admins to unassign 
a tutor from a specific subject block in a tutor request.

Changes:

Backend:
* Registered PATCH /v1/requestTutor/unassign/:requestTutorId route
* Added unassignTutor Joi validation schema
* Added unassignTutor service logic to remove assigned tutor per block
* Added unassignTutor controller to handle the unassignment request
* Added sendTutorUnassignedToRequester email template to notify 
  requester when a tutor is unassigned

File changed:
* src/routes/requestTutor.routes.js
* src/validations/requestTutor.validation.js
* src/services/requestTutor.service.js
* src/controllers/requestTutor.controllers.js
* src/services/email.service.js

Frontend:
* no frontend changes in this PR

Root Cause:
* No endpoint existed to unassign a tutor from a subject block once assigned

Result:
* Admins can unassign a tutor per subject block via the admin panel
* Requester receives an email notification on successful unassignment

Checklist:
* Self-reviewed code
* Verified PATCH /unassign/:requestTutorId returns correct response
* Verified unassignment removes tutor from the correct subject block
* Verified email notification triggers on successful unassignment
* Verified validation rejects invalid requestTutorId