### PR TITLE
Persist Rejection Reason for Tutor Requests

### DIFF
--- a/src/models/requestTutor.model.js
+++ b/src/models/requestTutor.model.js
@@ -41,6 +41,11 @@ const requestTutorSchema = mongoose.Schema(
       required: true,
       default: 'Pending',
     },
+    rejectionReason: {
+      type: String,
+      trim: true,
+      default: '',
+    },
     phoneNumber: {
       type: String,
       required: true,

--- a/src/services/requestTutor.service.js
+++ b/src/services/requestTutor.service.js
@@ -629,6 +629,13 @@ const updateStatusById = async (requestTutorId, status, rejectionReason) => {
 
   const previousStatus = tutorRequest.status;
   tutorRequest.status = status;
+
+  if (status === 'Rejected' && previousStatus !== 'Rejected') {
+    tutorRequest.rejectionReason = rejectionReason;
+  } else if (status !== 'Rejected') {
+    tutorRequest.rejectionReason = '';
+  }
+
   await tutorRequest.save();
 
   if (status === 'Rejected' && previousStatus !== 'Rejected') {


### PR DESCRIPTION
## Ticket
[TM-984](https://softvilmedia-team.atlassian.net/browse/TM-984)

## Summary
Stores the rejection reason on tutor request records when a request is rejected, so the admin portal can display the original reason later.

## Changes

### Frontend
* No frontend changes in this PR.

### Backend
* Added `rejectionReason` to the `RequestTutor` schema.
* Saved `rejectionReason` when a request transitions to `Rejected`.
* Cleared `rejectionReason` when a request moves out of `Rejected`.
* Kept the existing rejection email behavior using the submitted reason.

## Files Changed
* `src/models/requestTutor.model.js`
* `src/services/requestTutor.service.js`

## Root Cause
* The API accepted `rejectionReason` during status update but only used it for the email notification. It was not persisted on the request document, so later GET/list responses had no reason to return.

## Result
* Newly rejected tutor requests store their rejection reason.
* Admin portal can display the saved rejection reason for newly rejected requests.
* Older rejected requests without a stored reason remain unchanged.

## Checklist
* [x] Self-reviewed code
* [x] Tested locally
* [x] No unrelated changes included
* [x] Relevant tickets updated