### PR TITLE
perf(blog): improve blog listing performance with projection, limit cap and indexes

### DIFF
--- a/src/models/blog.model.js
+++ b/src/models/blog.model.js
@@ -106,6 +106,9 @@ blogSchema.pre('save', async function (next) {
 blogSchema.plugin(toJSON);
 blogSchema.plugin(paginate);
 
+blogSchema.index({ status: 1, createdAt: -1 });
+blogSchema.index({ tags: 1, status: 1 });
+
 /**
  * @typedef Blog
  */

--- a/src/services/blog.service.js
+++ b/src/services/blog.service.js
@@ -39,8 +39,9 @@ const queryBlogs = async (filter, options, user) => {
 
   const blogs = await Blog.paginate(query, {
     ...options,
-    populate: 'tags relatedArticles',
-    select: 'title slug author image content relatedArticles tags faqs status createdAt updatedAt',
+    limit: Math.min(options.limit || 20, 100),
+    populate: 'tags',
+    select: 'title slug author image tags status createdAt',
   });
 
   return blogs;

--- a/src/validations/blog.validation.js
+++ b/src/validations/blog.validation.js
@@ -96,7 +96,7 @@ const getBlogs = {
     tags: Joi.array().items(objectId()),
     status: Joi.string().valid('pending', 'approved', 'rejected'),
     sortBy: Joi.string(),
-    limit: Joi.number().integer(),
+    limit: Joi.number().integer().max(100),
     page: Joi.number().integer(),
   }),
 };


### PR DESCRIPTION
PR Description:

Summary: Improved blog listing API performance by adding field projection 
to reduce response payload, enforcing a request limit cap to prevent 
unbounded queries, and adding compound indexes for faster filtering.

Changes:

Frontend:
* no frontend changes in this PR

Backend:
* Added compound indexes on { status, createdAt } and { tags, status }
  for faster blog listing queries as collection grows
* Listing endpoint now returns only card-relevant fields — title, slug,
  author, image, tags, status, createdAt
* Full content and faqs remain available on the detail endpoint only
* Capped max limit at 100 per request via Joi validation
* Added service-level Math.min(limit, 100) clamp as a safety net

Files changed:
* src/models/blog.model.js
* src/services/blog.service.js
* src/validations/blog.validation.js

Root Cause:
* Listing endpoint was returning full blog content and faqs for every 
  card, causing unnecessary payload on every page load
* No limit cap meant the API could be hit with unbounded queries

Result:
* Listing response payload significantly reduced
* API protected from unbounded queries
* Queries are indexed for fast filtering as blog count grows
* Frontend infinite scroll with limit=12 per page works correctly

Checklist:
* Self-reviewed code
* Verified listing endpoint returns correct fields only
* Verified detail endpoint still returns full content
* Verified limit=12 from frontend passes validation
* Verified limit above 100 is rejected
* Verified indexes applied on blog collection