### PR TITLE
Add secure Telegram outreach and invite flow for tutor requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,4 +26,6 @@ EMAIL_FROM=support@yourapp.com
 ADMIN_EMAIL=admin@yourapp.com
 USER_APP_URL=https://www.tuitionlanka.com
 ADMIN_APP_URL=https://admin.tuitionlanka.com
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+TELEGRAM_TUTOR_GROUP_CHAT_ID=your-telegram-group-chat-id
 #config proper email server

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ SMTP_USERNAME=email-server-username
 SMTP_PASSWORD=email-server-password
 EMAIL_FROM=support@yourapp.com
 ADMIN_EMAIL=admin@yourapp.com
+ADMIN_WHATSAPP_NUMBER=947XXXXXXXX
 USER_APP_URL=https://www.tuitionlanka.com
 ADMIN_APP_URL=https://admin.tuitionlanka.com
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -24,6 +24,7 @@ const envVarsSchema = Joi.object()
     SMTP_PASSWORD: Joi.string().description('password for email server'),
     EMAIL_FROM: Joi.string().description('the from field in the emails sent by the app'),
     ADMIN_EMAIL: Joi.string().email().description('the admin email that receives tutor request match reports'),
+    ADMIN_WHATSAPP_NUMBER: Joi.string().description('the admin WhatsApp number tutors can contact for support'),
     USER_APP_URL: Joi.string().uri().description('the user portal base url'),
     ADMIN_APP_URL: Joi.string().uri().description('the admin portal base url'),
     TELEGRAM_BOT_TOKEN: Joi.string().description('Telegram bot token used for tutor outreach messages'),
@@ -71,6 +72,7 @@ module.exports = {
     },
     from: `"Tuition Lanka" <${process.env.EMAIL_FROM}>`,
     admin: envVars.ADMIN_EMAIL || envVars.EMAIL_FROM,
+    adminWhatsAppNumber: envVars.ADMIN_WHATSAPP_NUMBER,
   },
   app: {
     userUrl: envVars.USER_APP_URL || 'https://www.tuitionlanka.com',

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -26,6 +26,8 @@ const envVarsSchema = Joi.object()
     ADMIN_EMAIL: Joi.string().email().description('the admin email that receives tutor request match reports'),
     USER_APP_URL: Joi.string().uri().description('the user portal base url'),
     ADMIN_APP_URL: Joi.string().uri().description('the admin portal base url'),
+    TELEGRAM_BOT_TOKEN: Joi.string().description('Telegram bot token used for tutor outreach messages'),
+    TELEGRAM_TUTOR_GROUP_CHAT_ID: Joi.string().description('Telegram group/channel chat id for tutor outreach'),
   })
   .unknown();
 
@@ -73,5 +75,9 @@ module.exports = {
   app: {
     userUrl: envVars.USER_APP_URL || 'https://www.tuitionlanka.com',
     adminUrl: envVars.ADMIN_APP_URL || 'https://admin.tuitionlanka.com',
+  },
+  telegram: {
+    botToken: envVars.TELEGRAM_BOT_TOKEN,
+    tutorGroupChatId: envVars.TELEGRAM_TUTOR_GROUP_CHAT_ID,
   },
 };

--- a/src/controllers/requestTutor.controllers.js
+++ b/src/controllers/requestTutor.controllers.js
@@ -69,6 +69,11 @@ const sendTutorMatchReport = catchAsync(async (req, res) => {
   res.send(result);
 });
 
+const sendTelegramOutreach = catchAsync(async (req, res) => {
+  const result = await requestTutorService.sendTelegramOutreach(req.params.requestTutorId, req.user);
+  res.send(result);
+});
+
 module.exports = {
   createTutorRequest,
   getTutorRequests,
@@ -77,4 +82,5 @@ module.exports = {
   updateStatus,
   updateAssignedTutor,
   sendTutorMatchReport,
+  sendTelegramOutreach,
 };

--- a/src/models/requestTutor.model.js
+++ b/src/models/requestTutor.model.js
@@ -46,6 +46,15 @@ const requestTutorSchema = mongoose.Schema(
       required: true,
       trim: true,
     },
+    telegramOutreachSentAt: {
+      type: Date,
+      default: null,
+    },
+    telegramOutreachSentBy: {
+      type: mongoose.SchemaTypes.ObjectId,
+      ref: 'User',
+      default: null,
+    },
 
     tutors: [
       {

--- a/src/routes/v1/request-tutor.route.js
+++ b/src/routes/v1/request-tutor.route.js
@@ -36,4 +36,12 @@ router
     requestTutorController.sendTutorMatchReport
   );
 
+router
+  .route('/:requestTutorId/send-telegram-outreach')
+  .post(
+    auth('manageUsers'),
+    validate(requestTutorValidation.sendTelegramOutreach),
+    requestTutorController.sendTelegramOutreach
+  );
+
 module.exports = router;

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -2,6 +2,7 @@ const nodemailer = require('nodemailer');
 const config = require('../config/config');
 const logger = require('../config/logger');
 const { Grade, Subject } = require('../models');
+const telegramService = require('./telegram.service');
 
 const transport = nodemailer.createTransport(config.email.smtp);
 /* istanbul ignore next */
@@ -582,6 +583,55 @@ const sendTutorApprovedEmail = async (to, tutorName) => {
   try {
     const subject = 'Your Tutor Registration is Approved – TuitionLanka';
     const signInUrl = 'https://www.tuitionlanka.com?login=true';
+    let tutorRequestsTelegramGroupUrl = '';
+
+    try {
+      const inviteLink = await telegramService.createTutorInviteLink(tutorName);
+      tutorRequestsTelegramGroupUrl = inviteLink && inviteLink.invite_link ? inviteLink.invite_link : '';
+    } catch (telegramErr) {
+      logger.warn(`Failed to generate Telegram tutor invite link for ${to}: ${telegramErr.message}`);
+    }
+
+    const { adminWhatsAppNumber } = config.email;
+    const telegramSupportText = adminWhatsAppNumber
+      ? `If you have any issues joining the Telegram group, please contact the TuitionLanka admin on WhatsApp: ${adminWhatsAppNumber}`
+      : 'If you have any issues joining the Telegram group, please contact the TuitionLanka admin.';
+    const telegramSupportHtml = adminWhatsAppNumber
+      ? `If you have any issues joining the Telegram group, please contact the TuitionLanka admin on WhatsApp: <strong>${adminWhatsAppNumber}</strong>`
+      : 'If you have any issues joining the Telegram group, please contact the TuitionLanka admin.';
+
+    const telegramText = tutorRequestsTelegramGroupUrl
+      ? `To receive new tuition requests, please join our official Telegram group using your secure one-time invite link.
+
+This link can only be used once and will expire in 48 hours.
+${tutorRequestsTelegramGroupUrl}
+
+${telegramSupportText}`
+      : `We could not generate your secure Telegram invite link automatically. ${telegramSupportText}`;
+
+    const telegramHtml = tutorRequestsTelegramGroupUrl
+      ? `
+          <p>To receive new tuition requests, please join our official Telegram group using your secure one-time invite link.</p>
+          <p>This link can only be used once and will expire in 48 hours.</p>
+          <p style="text-align: center; margin: 24px 0;">
+            <a href="${tutorRequestsTelegramGroupUrl}"
+               style="background-color: #229ED9; color: #fff; padding: 13px 28px;
+                      border-radius: 8px; text-decoration: none; font-weight: bold; font-size: 15px;">
+              Join Telegram Group
+            </a>
+          </p>
+          <p style="color: #6b7280; font-size: 13px;">Or copy and paste this secure Telegram invite link into your browser:<br/>
+            <a href="${tutorRequestsTelegramGroupUrl}" style="color: #4F46E5; font-weight: bold;">${tutorRequestsTelegramGroupUrl}</a>
+          </p>
+          <p>${telegramSupportHtml}</p>
+        `
+      : `
+          <div style="background-color: #fff7ed; border-left: 4px solid #f97316; padding: 14px 18px; border-radius: 4px; margin: 22px 0;">
+            <p style="margin: 0; color: #9a3412;">
+              We could not generate your secure Telegram invite link automatically. ${telegramSupportHtml}
+            </p>
+          </div>
+        `;
 
     const text = `
 Dear ${tutorName},
@@ -590,6 +640,8 @@ Great news! Your tutor registration on TuitionLanka has been approved.
 
 You can now log in to the platform using the link below:
 ${signInUrl}
+
+${telegramText}
 
 Thank you for joining TuitionLanka. We look forward to connecting you with students!
 
@@ -619,6 +671,8 @@ TuitionLanka – Learn Better, Achieve More
           <p style="color: #6b7280; font-size: 13px;">Or copy this link into your browser:<br/>
             <a href="${signInUrl}" style="color: #4F46E5;">${signInUrl}</a>
           </p>
+
+          ${telegramHtml}
 
           <p>Thank you for joining TuitionLanka. We look forward to connecting you with students!</p>
 

--- a/src/services/requestTutor.service.js
+++ b/src/services/requestTutor.service.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const { RequestTutor, Tutor, Grade, Subject } = require('../models');
 const ApiError = require('../utils/ApiError');
 const emailService = require('./email.service');
+const telegramService = require('./telegram.service');
 const logger = require('../config/logger');
 const config = require('../config/config');
 
@@ -451,6 +452,52 @@ const buildTutorRequestMatchReport = async (requestTutor) => {
   };
 };
 
+const escapeTelegramHtml = (value) =>
+  String(value || 'N/A')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+const buildTelegramOutreachMessage = async (requestTutor) => {
+  const [gradeDoc, blockSubjectDocs] = await Promise.all([
+    resolveGradeDoc(requestTutor.grade),
+    Promise.all(
+      (requestTutor.tutors || []).map(async (tutorBlock) => {
+        const subjectDoc = await resolveSubjectDoc(tutorBlock.subject);
+        return {
+          tutorBlock,
+          subjectTitle: subjectDoc ? subjectDoc.title : tutorBlock.subject,
+        };
+      })
+    ),
+  ]);
+
+  const lines = [
+    '<b>New tutor request</b>',
+    '',
+    `District: ${escapeTelegramHtml(requestTutor.district)}`,
+    `City: ${escapeTelegramHtml(requestTutor.city)}`,
+    `Medium: ${escapeTelegramHtml(requestTutor.medium)}`,
+    `Grade: ${escapeTelegramHtml(gradeDoc ? gradeDoc.title : requestTutor.grade)}`,
+  ];
+
+  blockSubjectDocs.forEach(({ tutorBlock, subjectTitle }, index) => {
+    lines.push(
+      '',
+      `<b>Request ${index + 1}</b>`,
+      `Subject: ${escapeTelegramHtml(subjectTitle)}`,
+      `Preferred tutor type: ${escapeTelegramHtml(tutorBlock.preferredTutorType)}`,
+      `Class type: ${escapeTelegramHtml(tutorBlock.preferredClassType)}`,
+      `Duration: ${escapeTelegramHtml(tutorBlock.duration)}`,
+      `Frequency: ${escapeTelegramHtml(tutorBlock.frequency)}`
+    );
+  });
+
+  lines.push('', 'Please reply in this group if available outside your usual slots.');
+
+  return lines.join('\n');
+};
+
 const sendAcknowledgement = async (requestTutorBody) => {
   try {
     await emailService.sendAcknowledgement(requestTutorBody);
@@ -555,6 +602,58 @@ const sendTutorMatchReportToAdmin = async (requestTutorId) => {
   };
 };
 
+const sendTelegramOutreach = async (requestTutorId, adminUser) => {
+  const requestTutorDoc = await getRequestTutorById(requestTutorId);
+
+  if (!requestTutorDoc) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Tutor request not found');
+  }
+
+  if (requestTutorDoc.telegramOutreachSentAt) {
+    throw new ApiError(httpStatus.CONFLICT, 'Telegram outreach has already been sent for this tutor request');
+  }
+
+  const message = await buildTelegramOutreachMessage(requestTutorDoc);
+  const sentAt = new Date();
+  const sentBy = adminUser && adminUser.id ? adminUser.id : null;
+
+  const reservedRequest = await RequestTutor.findOneAndUpdate(
+    {
+      _id: requestTutorId,
+      $or: [{ telegramOutreachSentAt: { $exists: false } }, { telegramOutreachSentAt: null }],
+    },
+    {
+      $set: {
+        telegramOutreachSentAt: sentAt,
+        telegramOutreachSentBy: sentBy,
+      },
+    },
+    { new: true }
+  );
+
+  if (!reservedRequest) {
+    throw new ApiError(httpStatus.CONFLICT, 'Telegram outreach has already been sent for this tutor request');
+  }
+
+  try {
+    const telegramResult = await telegramService.sendMessage(message);
+
+    return {
+      message: 'Tutor request sent to Telegram',
+      requestTutorId: reservedRequest.id,
+      telegramOutreachSentAt: reservedRequest.telegramOutreachSentAt,
+      telegramOutreachSentBy: reservedRequest.telegramOutreachSentBy,
+      telegramMessageId: telegramResult && telegramResult.message_id,
+    };
+  } catch (err) {
+    await RequestTutor.updateOne(
+      { _id: requestTutorId, telegramOutreachSentAt: sentAt },
+      { $set: { telegramOutreachSentAt: null, telegramOutreachSentBy: null } }
+    );
+    throw err;
+  }
+};
+
 /**
  * Delete tutor request
  */
@@ -651,4 +750,5 @@ module.exports = {
   updateStatusById,
   updateAssignedTutor,
   sendTutorMatchReportToAdmin,
+  sendTelegramOutreach,
 };

--- a/src/services/requestTutor.service.js
+++ b/src/services/requestTutor.service.js
@@ -458,14 +458,32 @@ const escapeTelegramHtml = (value) =>
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
+const isTutorBlockAssigned = (tutorBlock) => Boolean(tutorBlock && String(tutorBlock.assignedTutor || '').trim());
+
+const getShortReference = (id) => {
+  const safeId = String(id || '').trim();
+  return safeId ? safeId.slice(-6).toUpperCase() : 'N/A';
+};
+
 const buildTelegramOutreachMessage = async (requestTutor) => {
+  const requestId = String(requestTutor.id || requestTutor._id || '');
+  const shortRequestRef = getShortReference(requestId);
+  const unassignedTutorBlocks = (requestTutor.tutors || [])
+    .map((tutorBlock, index) => ({ tutorBlock, requestNumber: index + 1 }))
+    .filter(({ tutorBlock }) => !isTutorBlockAssigned(tutorBlock));
+
+  if (unassignedTutorBlocks.length === 0) {
+    throw new ApiError(httpStatus.BAD_REQUEST, 'All tutor request blocks are already assigned');
+  }
+
   const [gradeDoc, blockSubjectDocs] = await Promise.all([
     resolveGradeDoc(requestTutor.grade),
     Promise.all(
-      (requestTutor.tutors || []).map(async (tutorBlock) => {
+      unassignedTutorBlocks.map(async ({ tutorBlock, requestNumber }) => {
         const subjectDoc = await resolveSubjectDoc(tutorBlock.subject);
         return {
           tutorBlock,
+          requestNumber,
           subjectTitle: subjectDoc ? subjectDoc.title : tutorBlock.subject,
         };
       })
@@ -475,16 +493,18 @@ const buildTelegramOutreachMessage = async (requestTutor) => {
   const lines = [
     '<b>New tutor request</b>',
     '',
+    `Tutor request ref: ${escapeTelegramHtml(shortRequestRef)}`,
     `District: ${escapeTelegramHtml(requestTutor.district)}`,
     `City: ${escapeTelegramHtml(requestTutor.city)}`,
     `Medium: ${escapeTelegramHtml(requestTutor.medium)}`,
     `Grade: ${escapeTelegramHtml(gradeDoc ? gradeDoc.title : requestTutor.grade)}`,
   ];
 
-  blockSubjectDocs.forEach(({ tutorBlock, subjectTitle }, index) => {
+  blockSubjectDocs.forEach(({ tutorBlock, requestNumber, subjectTitle }) => {
     lines.push(
       '',
-      `<b>Request ${index + 1}</b>`,
+      `<b>Request ${requestNumber}</b>`,
+      `Request ref: ${escapeTelegramHtml(getShortReference(tutorBlock.id || tutorBlock._id))}`,
       `Subject: ${escapeTelegramHtml(subjectTitle)}`,
       `Preferred tutor type: ${escapeTelegramHtml(tutorBlock.preferredTutorType)}`,
       `Class type: ${escapeTelegramHtml(tutorBlock.preferredClassType)}`,

--- a/src/services/telegram.service.js
+++ b/src/services/telegram.service.js
@@ -1,0 +1,69 @@
+const https = require('https');
+const httpStatus = require('http-status');
+const config = require('../config/config');
+const ApiError = require('../utils/ApiError');
+
+const sendMessage = async (text) => {
+  const { botToken, tutorGroupChatId } = config.telegram;
+
+  if (!botToken || !tutorGroupChatId) {
+    throw new ApiError(httpStatus.INTERNAL_SERVER_ERROR, 'Telegram outreach is not configured');
+  }
+
+  const payload = JSON.stringify({
+    chat_id: tutorGroupChatId,
+    text,
+    parse_mode: 'HTML',
+    disable_web_page_preview: true,
+  });
+
+  const options = {
+    hostname: 'api.telegram.org',
+    path: `/bot${botToken}/sendMessage`,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(payload),
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(options, (response) => {
+      let responseBody = '';
+
+      response.on('data', (chunk) => {
+        responseBody += chunk;
+      });
+
+      response.on('end', () => {
+        let parsedBody;
+
+        try {
+          parsedBody = responseBody ? JSON.parse(responseBody) : {};
+        } catch (parseError) {
+          return reject(
+            new ApiError(httpStatus.BAD_GATEWAY, 'Telegram returned an invalid response', true, parseError.stack)
+          );
+        }
+
+        if (response.statusCode < 200 || response.statusCode >= 300 || parsedBody.ok === false) {
+          const description = parsedBody.description || 'Telegram outreach failed';
+          return reject(new ApiError(httpStatus.BAD_GATEWAY, description));
+        }
+
+        return resolve(parsedBody.result);
+      });
+    });
+
+    request.on('error', () => {
+      reject(new ApiError(httpStatus.BAD_GATEWAY, 'Unable to reach Telegram'));
+    });
+
+    request.write(payload);
+    request.end();
+  });
+};
+
+module.exports = {
+  sendMessage,
+};

--- a/src/services/telegram.service.js
+++ b/src/services/telegram.service.js
@@ -3,23 +3,16 @@ const httpStatus = require('http-status');
 const config = require('../config/config');
 const ApiError = require('../utils/ApiError');
 
-const sendMessage = async (text) => {
-  const { botToken, tutorGroupChatId } = config.telegram;
-
-  if (!botToken || !tutorGroupChatId) {
-    throw new ApiError(httpStatus.INTERNAL_SERVER_ERROR, 'Telegram outreach is not configured');
+const telegramRequest = async (method, body, fallbackErrorMessage) => {
+  const { botToken } = config.telegram;
+  if (!botToken) {
+    throw new ApiError(httpStatus.INTERNAL_SERVER_ERROR, 'Telegram bot token is not configured');
   }
 
-  const payload = JSON.stringify({
-    chat_id: tutorGroupChatId,
-    text,
-    parse_mode: 'HTML',
-    disable_web_page_preview: true,
-  });
-
+  const payload = JSON.stringify(body);
   const options = {
     hostname: 'api.telegram.org',
-    path: `/bot${botToken}/sendMessage`,
+    path: `/bot${botToken}/${method}`,
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -47,7 +40,7 @@ const sendMessage = async (text) => {
         }
 
         if (response.statusCode < 200 || response.statusCode >= 300 || parsedBody.ok === false) {
-          const description = parsedBody.description || 'Telegram outreach failed';
+          const description = parsedBody.description || fallbackErrorMessage;
           return reject(new ApiError(httpStatus.BAD_GATEWAY, description));
         }
 
@@ -64,6 +57,50 @@ const sendMessage = async (text) => {
   });
 };
 
+const ensureTutorGroupConfigured = () => {
+  const { tutorGroupChatId } = config.telegram;
+
+  if (!tutorGroupChatId) {
+    throw new ApiError(httpStatus.INTERNAL_SERVER_ERROR, 'Telegram tutor group is not configured');
+  }
+
+  return tutorGroupChatId;
+};
+
+const sendMessage = async (text) => {
+  const tutorGroupChatId = ensureTutorGroupConfigured();
+
+  return telegramRequest(
+    'sendMessage',
+    {
+      chat_id: tutorGroupChatId,
+      text,
+      parse_mode: 'HTML',
+      disable_web_page_preview: true,
+    },
+    'Telegram outreach failed'
+  );
+};
+
+const createTutorInviteLink = async (tutorName) => {
+  const tutorGroupChatId = ensureTutorGroupConfigured();
+  const expiresInSeconds = 48 * 60 * 60;
+  const expireDate = Math.floor(Date.now() / 1000) + expiresInSeconds;
+  const inviteName = `Tutor ${tutorName || 'Invite'}`.slice(0, 32);
+
+  return telegramRequest(
+    'createChatInviteLink',
+    {
+      chat_id: tutorGroupChatId,
+      name: inviteName,
+      expire_date: expireDate,
+      member_limit: 1,
+    },
+    'Telegram invite link creation failed'
+  );
+};
+
 module.exports = {
   sendMessage,
+  createTutorInviteLink,
 };

--- a/src/validations/requestTutor.validation.js
+++ b/src/validations/requestTutor.validation.js
@@ -206,6 +206,19 @@ const sendTutorMatchReport = {
   }),
 };
 
+const sendTelegramOutreach = {
+  params: Joi.object().keys({
+    requestTutorId: Joi.string()
+      .custom((value, helpers) => {
+        if (!mongoose.Types.ObjectId.isValid(value)) {
+          return helpers.message('Invalid request tutor ID');
+        }
+        return value;
+      })
+      .required(),
+  }),
+};
+
 module.exports = {
   createRequestTutor,
   getTutors,
@@ -214,4 +227,5 @@ module.exports = {
   updateStatus,
   updateAssignedTutor,
   sendTutorMatchReport,
+  sendTelegramOutreach,
 };


### PR DESCRIPTION
## Ticket
[TM-967](https://softvilmedia-team.atlassian.net/browse/TM-967)

## Summary
Adds backend support for Telegram tutor outreach, secure one-time Telegram group invites for approved tutors, admin WhatsApp support in approval emails, and request references so admins can match Telegram replies to the correct tutor request.

## Changes

### Frontend
No frontend changes in this PR

### Backend
* Added Telegram outreach support for tutor requests.
* Added Telegram sent-status tracking to prevent duplicate outreach sends.
* Added secure one-time Telegram invite link generation for approved tutors.
* Updated tutor approval email to include a dynamic secure Telegram invite link.
* Added configurable admin WhatsApp support number for invite issues.
* Avoided exposing hardcoded reusable Telegram group invite links.
* Updated Telegram outreach messages to send only unassigned tutor request blocks.
* Added display-only Telegram refs:
  * `Tutor request ref`
  * per-block `Request ref`
* Added request tutor rejection reason validation and handling.
* Added backend support for saving and displaying rejected tutor request reasons.
* Preserved unassign tutor flow during merge conflict resolution.

## Files Changed
* `src/config/config.js`
* `.env.example`
* `src/services/telegram.service.js`
* `src/services/email.service.js`
* `src/services/requestTutor.service.js`
* `src/controllers/requestTutor.controllers.js`
* `src/routes/v1/request-tutor.route.js`
* `src/models/requestTutor.model.js`
* `src/validations/requestTutor.validation.js`

## Root Cause
* Admins needed a safe way to broadcast open tutor request blocks to the private Telegram group without duplicate sends.
* Approved tutors needed a secure way to join the Telegram group without leaking a reusable invite link.
* Admins needed shared references to match Telegram replies back to tutor request blocks without exposing requester names.
* Rejected tutor requests needed clear reason capture and validation.

## Result
* Admins can send tutor request outreach to Telegram from the admin panel.
* Telegram outreach only includes unassigned request blocks.
* Duplicate Telegram sends are blocked.
* Approved tutors receive a secure one-time invite link that expires in 48 hours.
* Tutors can contact admin via WhatsApp if invite generation or joining fails.
* Admins can match Telegram replies using `Tutor request ref` and `Request ref`.
* Rejected tutor requests retain the rejection reason for follow-up and display.