### PR TITLE
fix: Add search support and tuition rates pagination

### DIFF
--- a/src/controllers/tuition-rates.controller.js
+++ b/src/controllers/tuition-rates.controller.js
@@ -10,7 +10,7 @@ const createTuitionRate = catchAsync(async (req, res) => {
 });
 
 const queryTuitionRates = catchAsync(async (req, res) => {
-  const filter = pick(req.query, ['subject', 'grade']);
+  const filter = pick(req.query, ['search', 'subject', 'grade']);
   const options = {
     ...pick(req.query, ['sortBy', 'limit', 'page']),
   };
@@ -21,7 +21,7 @@ const queryTuitionRates = catchAsync(async (req, res) => {
 });
 
 const getTuitionRatesByGrade = catchAsync(async (req, res) => {
-  const filter = pick(req.query, ['subject']);
+  const filter = pick(req.query, ['search', 'subject']);
   const options = {
     ...pick(req.query, ['sortBy', 'limit', 'page']),
   };

--- a/src/services/tuitionRates.service.js
+++ b/src/services/tuitionRates.service.js
@@ -1,6 +1,32 @@
 const httpStatus = require('http-status');
-const { TuitionRates } = require('../models');
+const { Grade, Subject, TuitionRates } = require('../models');
 const ApiError = require('../utils/ApiError');
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const buildTuitionRateSearchQuery = async (filter = {}) => {
+  const query = { ...filter };
+  const searchTerm = typeof query.search === 'string' ? query.search.trim() : '';
+
+  delete query.search;
+
+  if (!searchTerm) {
+    return query;
+  }
+
+  const searchRegex = new RegExp(escapeRegex(searchTerm), 'i');
+  const [grades, subjects] = await Promise.all([
+    Grade.find({ title: searchRegex }).select('_id').lean(),
+    Subject.find({ title: searchRegex }).select('_id').lean(),
+  ]);
+
+  const gradeIds = grades.map((grade) => grade._id);
+  const subjectIds = subjects.map((subject) => subject._id);
+
+  query.$or = [{ grade: { $in: gradeIds } }, { subject: { $in: subjectIds } }];
+
+  return query;
+};
 
 /**
  * Create a Tuition Rate
@@ -18,7 +44,8 @@ const createTuitionRate = async (tuitionRateBody) => {
  * @returns {Promise<QueryResult>}
  */
 const queryTuitionRates = async (filter, options) => {
-  const tuitionRates = await TuitionRates.paginate(filter, {
+  const query = await buildTuitionRateSearchQuery(filter);
+  const tuitionRates = await TuitionRates.paginate(query, {
     ...options,
     populate: 'grade subject',
   });
@@ -26,10 +53,10 @@ const queryTuitionRates = async (filter, options) => {
 };
 
 const getTuitionRatesByGradeId = async (gradeId, filter, options) => {
-  const query = {
+  const query = await buildTuitionRateSearchQuery({
     grade: gradeId,
     ...filter,
-  };
+  });
 
   const tuitionRates = await TuitionRates.paginate(query, {
     ...options,

--- a/src/validations/tuitionRates.validation.js
+++ b/src/validations/tuitionRates.validation.js
@@ -28,6 +28,7 @@ const createTuitionRate = {
 // Get tuition rates validation
 const getTuitionRates = {
   query: Joi.object().keys({
+    search: Joi.string().allow(''),
     subject: Joi.string(),
     grade: Joi.string(),
     sortBy: Joi.string(),
@@ -38,9 +39,10 @@ const getTuitionRates = {
 
 const getTuitionRatesByGrade = {
   params: Joi.object().keys({
-    tuitionRatesId: idValidator,
+    gradeId: idValidator,
   }),
   query: Joi.object().keys({
+    search: Joi.string().allow(''),
     subject: Joi.string(),
     sortBy: Joi.string(),
     limit: Joi.number().integer(),


### PR DESCRIPTION
## Summary

- Added `search` query support to paginated tuition rates endpoints.
- Search now matches related `Grade.title` and `Subject.title`, then filters tuition rate records by matching grade/subject IDs.
- Forwarded `search` through the tuition rates controller and validation layer.
- Fixed `GET /v1/tuitionRates/by-grade/:gradeId` validation to use the correct `gradeId` route param.

## Updated Endpoints

- `GET /v1/tuitionRates`
- `GET /v1/tuitionRates/by-grade/:gradeId`

## Supported Query Params

- `page`
- `limit`
- `sortBy`
- `search`
- `grade`
- `subject`

## Example Requests

```http
GET /v1/tuitionRates?page=1&limit=10&search=math
GET /v1/tuitionRates?grade=<gradeId>&subject=<subjectId>&page=2&limit=20
GET /v1/tuitionRates/by-grade/<gradeId>?page=1&limit=10&search=english