### PR TITLE
fix: adding backend pagination instead of loading a large batch and filtering locally

### DIFF
--- a/src/controllers/paper.controller.js
+++ b/src/controllers/paper.controller.js
@@ -10,7 +10,7 @@ const createPaper = catchAsync(async (req, res) => {
 });
 
 const getPapers = catchAsync(async (req, res) => {
-  const filter = pick(req.query, ['title', 'grade', 'subject', 'medium']);
+  const filter = pick(req.query, ['title', 'year', 'yearSearch', 'grade', 'subject', 'medium']);
 
   const options = { ...pick(req.query, ['sortBy', 'limit', 'page', 'order']), populate: 'grade,subject' };
 

--- a/src/services/paper.service.js
+++ b/src/services/paper.service.js
@@ -27,10 +27,26 @@ const preparePaperData = (paperBody) => {
 
 const preparePaperQuery = (filter) => {
   const query = { ...filter };
+  const yearSearch = typeof query.yearSearch === 'string' ? query.yearSearch.trim() : '';
+
+  delete query.yearSearch;
 
   if (query.medium !== undefined) {
     const normalizedMedium = normalizeMediumOrThrow(query.medium);
     query.medium = { $regex: `^${escapeRegex(normalizedMedium)}$`, $options: 'i' };
+  }
+
+  if (query.title !== undefined) {
+    query.title = { $regex: escapeRegex(query.title), $options: 'i' };
+  }
+
+  if (yearSearch) {
+    query.$expr = {
+      $regexMatch: {
+        input: { $toString: '$year' },
+        regex: escapeRegex(yearSearch),
+      },
+    };
   }
 
   return query;

--- a/src/validations/paper.validation.js
+++ b/src/validations/paper.validation.js
@@ -26,6 +26,8 @@ const createPaper = {
 const getPapers = {
   query: Joi.object().keys({
     title: Joi.string(),
+    year: Joi.number().integer(),
+    yearSearch: Joi.string().pattern(/^\d+$/).allow(''),
     grade: Joi.string().custom(objectId),
     subject: Joi.string().custom(objectId),
     medium: Joi.string().custom(paperMedium),


### PR DESCRIPTION
## Summary

- Added `year` as a supported filter for `GET /v1/papers`.
- Added `yearSearch` for partial year matching, e.g. `yearSearch=20` matches years like `2020` and `2021`.
- Updated paper title filtering to be case-insensitive and partial-match.
- Kept existing pagination support using `page` and `limit`.

## Updated Endpoint

- `GET /v1/papers`

## Supported Query Params

- `title`
- `year`
- `yearSearch`
- `grade`
- `subject`
- `medium`
- `sortBy`
- `limit`
- `page`
- `order`
