### PR TITLE
fix: Added pagination support to subjects-by-grades 

### DIFF
--- a/src/controllers/grade.controller.js
+++ b/src/controllers/grade.controller.js
@@ -28,13 +28,11 @@ const getGrade = catchAsync(async (req, res) => {
 
 const getSubjectsForGrades = catchAsync(async (req, res) => {
   const { gradeIds } = req.body;
+  const options = pick(req.body, ['sortBy', 'limit', 'page']);
 
-  const subjects = await gradeService.getSubjectsForGrades(gradeIds);
+  const result = await gradeService.getSubjectsForGrades(gradeIds, options);
 
-  res.send({
-    count: subjects.length,
-    subjects,
-  });
+  res.send(result);
 });
 
 const getGradesWithCounts = catchAsync(async (req, res) => {

--- a/src/services/grade.service.js
+++ b/src/services/grade.service.js
@@ -38,13 +38,75 @@ const getGradeById = async (id) => {
   return Grade.findById(id).populate('subjects');
 };
 
-const getSubjectsForGrades = async (gradeIds) => {
+const getValueByPath = (object, path) =>
+  path.split('.').reduce((value, key) => (value === undefined || value === null ? undefined : value[key]), object);
+
+const sortResults = (results, sortBy) => {
+  if (!sortBy) {
+    return results;
+  }
+
+  const sortingCriteria = sortBy.split(',').map((sortOption) => {
+    const [key, order] = sortOption.split(':');
+    return {
+      key,
+      direction: order === 'desc' ? -1 : 1,
+    };
+  });
+
+  return [...results].sort((left, right) =>
+    sortingCriteria.reduce((comparison, { key, direction }) => {
+      if (comparison !== 0) {
+        return comparison;
+      }
+
+      const leftValue = getValueByPath(left, key);
+      const rightValue = getValueByPath(right, key);
+
+      if (leftValue === rightValue) {
+        return 0;
+      }
+
+      if (leftValue === undefined || leftValue === null) {
+        return -1 * direction;
+      }
+
+      if (rightValue === undefined || rightValue === null) {
+        return 1 * direction;
+      }
+
+      return String(leftValue).localeCompare(String(rightValue), undefined, { numeric: true }) * direction;
+    }, 0)
+  );
+};
+
+const paginateResults = (results, options = {}) => {
+  const shouldPaginate = options.page !== undefined || options.limit !== undefined;
+  const totalResults = results.length;
+  const limit = shouldPaginate && parseInt(options.limit, 10) > 0 ? parseInt(options.limit, 10) : totalResults || 10;
+  const page = shouldPaginate && parseInt(options.page, 10) > 0 ? parseInt(options.page, 10) : 1;
+  const skip = (page - 1) * limit;
+  const pagedResults = shouldPaginate ? results.slice(skip, skip + limit) : results;
+  const totalPages = Math.ceil(totalResults / limit);
+
+  return {
+    results: pagedResults,
+    subjects: pagedResults,
+    count: totalResults,
+    page,
+    limit,
+    totalPages,
+    totalResults,
+  };
+};
+
+const getSubjectsForGrades = async (gradeIds, options = {}) => {
   const grades = await Grade.find({
     _id: { $in: gradeIds },
   }).populate('subjects');
 
   if (!grades.length) {
-    return [];
+    return paginateResults([], options);
   }
 
   const subjectMap = new Map();
@@ -55,7 +117,9 @@ const getSubjectsForGrades = async (gradeIds) => {
     });
   });
 
-  return Array.from(subjectMap.values());
+  const subjects = sortResults(Array.from(subjectMap.values()), options.sortBy);
+
+  return paginateResults(subjects, options);
 };
 
 const getGradesWithTuitionRateCounts = async () => {

--- a/src/validations/grade.validation.js
+++ b/src/validations/grade.validation.js
@@ -46,6 +46,9 @@ const getSubjectsForGrades = {
       )
       .min(1)
       .required(),
+    sortBy: Joi.string(),
+    limit: Joi.number().integer(),
+    page: Joi.number().integer(),
   }),
 };
 


### PR DESCRIPTION
## Summary

- Added pagination support to `POST /v1/grades/subjects-by-grades`.
- Added optional `page`, `limit`, and `sortBy` body params for paginating subjects returned for selected grades.
- Updated the response to include standard pagination metadata.
- Preserved the existing `subjects` response field as an alias of `results` for compatibility.

## Updated Endpoint

- `POST /v1/grades/subjects-by-grades`
