### PR TITLE
fix: Added sender name and sender email query parameters

### DIFF
--- a/src/controllers/inquiry.controller.js
+++ b/src/controllers/inquiry.controller.js
@@ -10,7 +10,7 @@ const createInquiry = catchAsync(async (req, res) => {
 });
 
 const getInquiries = catchAsync(async (req, res) => {
-  const filter = pick(req.query, ['author', 'sender']);
+  const filter = pick(req.query, ['message', 'name', 'email']);
   const options = {
     ...pick(req.query, ['sortBy', 'limit', 'page']),
   };

--- a/src/services/inquiry.service.js
+++ b/src/services/inquiry.service.js
@@ -2,6 +2,28 @@ const httpStatus = require('http-status');
 const ApiError = require('../utils/ApiError');
 const { Inquiry } = require('../models');
 
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const prepareInquiryQuery = (filter = {}) => {
+  const query = { ...filter };
+
+  if (query.message) {
+    query.message = { $regex: escapeRegex(query.message), $options: 'i' };
+  }
+
+  if (query.name) {
+    query['sender.name'] = { $regex: escapeRegex(query.name), $options: 'i' };
+    delete query.name;
+  }
+
+  if (query.email) {
+    query['sender.email'] = { $regex: escapeRegex(query.email), $options: 'i' };
+    delete query.email;
+  }
+
+  return query;
+};
+
 /**
  * Create an inquiry
  * @param {Object} inquiryBody
@@ -21,7 +43,7 @@ const createInquiry = async (inquiryBody) => {
  * @returns {Promise<QueryResult>}
  */
 const queryInquiries = async (filter, options) => {
-  const inquiries = await Inquiry.paginate(filter, options);
+  const inquiries = await Inquiry.paginate(prepareInquiryQuery(filter), options);
   return inquiries;
 };
 

--- a/src/validations/inquiry.validation.js
+++ b/src/validations/inquiry.validation.js
@@ -14,6 +14,8 @@ const createInquiry = {
 const getInquiries = {
   query: Joi.object().keys({
     message: Joi.string(),
+    name: Joi.string(),
+    email: Joi.string(),
     sortBy: Joi.string(),
     limit: Joi.number().integer(),
     page: Joi.number().integer(),


### PR DESCRIPTION
## Summary

- Added working search/filter support to `GET /v1/inquiries`.
- Added sender name and sender email query parameters.
- Updated inquiry message filtering to be case-insensitive and partial-match.
- Fixed the previous controller/validation mismatch where inquiry filters were not wired correctly.

## Updated Endpoint

- `GET /v1/inquiries`

## Supported Query Params

- `message`
- `name`
- `email`
- `sortBy`
- `limit`
- `page`
