### PR TITLE
fix: added ratings as a supported filter and added backend pagination

### DIFF
--- a/src/controllers/testimonial.controller.js
+++ b/src/controllers/testimonial.controller.js
@@ -10,7 +10,7 @@ const createTestimonial = catchAsync(async (req, res) => {
 });
 
 const getTestimonials = catchAsync(async (req, res) => {
-  const filter = pick(req.query, ['author', 'content']);
+  const filter = pick(req.query, ['content', 'rating']);
   const options = {
     ...pick(req.query, ['sortBy', 'limit', 'page']),
   };

--- a/src/services/testimonial.service.js
+++ b/src/services/testimonial.service.js
@@ -2,6 +2,18 @@ const httpStatus = require('http-status');
 const ApiError = require('../utils/ApiError');
 const { Testimonial } = require('../models');
 
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const prepareTestimonialQuery = (filter = {}) => {
+  const query = { ...filter };
+
+  if (query.content) {
+    query.content = { $regex: escapeRegex(query.content), $options: 'i' };
+  }
+
+  return query;
+};
+
 /**
  * Create a testimonial
  * @param {Object} testimonialBody
@@ -21,7 +33,7 @@ const createTestimonial = async (testimonialBody) => {
  * @returns {Promise<QueryResult>}
  */
 const queryTestimonials = async (filter, options) => {
-  const testimonials = await Testimonial.paginate(filter, options);
+  const testimonials = await Testimonial.paginate(prepareTestimonialQuery(filter), options);
   return testimonials;
 };
 

--- a/src/validations/testimonial.validation.js
+++ b/src/validations/testimonial.validation.js
@@ -15,7 +15,8 @@ const createTestimonials = {
 
 const getTestimonials = {
   query: Joi.object().keys({
-    title: Joi.string(),
+    content: Joi.string(),
+    rating: Joi.number(),
     sortBy: Joi.string(),
     limit: Joi.number().integer(),
     page: Joi.number().integer(),


### PR DESCRIPTION
## Summary

- Added `rating` as a supported filter for `GET /v1/testimonials`.
- Replaced the unused `title` query validation with real testimonial filters.
- Added working `content` search with case-insensitive partial matching.
- Fixed the controller/validation mismatch for testimonial list filters.
- Kept existing pagination support with `page` and `limit`.

## Updated Endpoint

- `GET /v1/testimonials`

## Supported Query Params

- `content`
- `rating`
- `sortBy`
- `limit`
- `page`
