### PR TITLE
Feat/tuition rates subjects display

### DIFF
--- a/scripts/seed-missing-rates.js
+++ b/scripts/seed-missing-rates.js
@@ -1,0 +1,217 @@
+/* eslint-disable */
+/**
+ * seed-missing-rates.js
+ *
+ * Uses the existing API to create TuitionRate records for every subject
+ * in a grade that has no rate configured yet.
+ *
+ * Safe:
+ *   - Only calls POST /tuition-rates (same as admin panel)
+ *   - Never updates or deletes existing records
+ *   - Duplicate insert blocked by the API's unique index (409 / 400 skipped)
+ *   - Grades with zero rates are skipped (nothing to copy from)
+ *
+ * Usage:
+ *   node scripts/seed-missing-rates.js              ← dry run (logs only, no writes)
+ *   node scripts/seed-missing-rates.js --apply      ← actually creates records
+ *
+ * Set env vars or edit the CONFIG block below before running.
+ */
+
+const BASE_URL = process.env.API_URL || 'http://localhost:3000/v1';
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@tuitionlanka.com';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || '';
+const DRY_RUN = !process.argv.includes('--apply');
+
+// Fallback rates for grades that have zero configured rates in the DB.
+// Values taken from production screenshots.
+const GRADE_FALLBACK_RATES = {
+  'G.C.E Advanced Level (Technology Stream)': {
+    universityStudentsRate: { minimumRate: 1000, maximumRate: 2500 },
+    partTimeTutorRate:      { minimumRate: 1500, maximumRate: 3500 },
+    fullTimeTutorRate:      { minimumRate: 2000, maximumRate: 5000 },
+    moeTeacherRate:         { minimumRate: 2500, maximumRate: 6000 },
+  },
+  'Diplomas': {
+    universityStudentsRate: { minimumRate: 1500, maximumRate: 3000 },
+    partTimeTutorRate:      { minimumRate: 2000, maximumRate: 4000 },
+    fullTimeTutorRate:      { minimumRate: 2000, maximumRate: 6000 },
+    moeTeacherRate:         { minimumRate: 2500, maximumRate: 8000 },
+  },
+};
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+async function api(path, { method = 'GET', token, body } = {}) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, data: json };
+}
+
+// ─── main ────────────────────────────────────────────────────────────────────
+
+async function run() {
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log(DRY_RUN ? '  DRY RUN — no records will be created' : '  APPLY MODE — records will be created');
+  console.log(`  API: ${BASE_URL}`);
+  console.log(`${'─'.repeat(60)}\n`);
+
+  // 1. Login
+  if (!ADMIN_PASSWORD) {
+    console.error('❌  Set ADMIN_PASSWORD env var before running.');
+    process.exit(1);
+  }
+
+  const loginRes = await api('/auth/login', {
+    method: 'POST',
+    body: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+  });
+
+  if (loginRes.status !== 200) {
+    console.error('❌  Login failed:', (loginRes.data && loginRes.data.message) || loginRes.status);
+    process.exit(1);
+  }
+
+  const token = loginRes.data && loginRes.data.tokens && loginRes.data.tokens.access && loginRes.data.tokens.access.token;
+  console.log(`✓ Logged in as ${ADMIN_EMAIL}\n`);
+
+  // 2. Fetch all grades (large limit to get all at once)
+  const gradesRes = await api('/grades?limit=200');
+  const grades = gradesRes.data.results || gradesRes.data.grades || [];
+
+  if (!grades.length) {
+    console.log('No grades found. Exiting.');
+    return;
+  }
+
+  console.log(`Found ${grades.length} grades\n`);
+
+  let totalCreated = 0;
+  let totalSkipped = 0;
+  let totalAlreadyExist = 0;
+
+  for (const grade of grades) {
+    const gradeId = grade.id || grade._id;
+
+    // 3. Get grade detail with subjects
+    const gradeDetailRes = await api(`/grades/${gradeId}`);
+    const subjects = gradeDetailRes.data.subjects || [];
+
+    if (!subjects.length) {
+      console.log(`[SKIP] "${grade.title}" — no subjects`);
+      totalSkipped++;
+      continue;
+    }
+
+    // 4. Get existing tuition rates for this grade directly from TuitionRates collection
+    let existingRates = [];
+    let page = 1;
+    while (true) {
+      const ratesRes = await api(`/tuitionRates?grade=${gradeId}&limit=200&page=${page}`);
+      const results = ratesRes.data.results || [];
+      existingRates = existingRates.concat(results);
+      if (page >= (ratesRes.data.totalPages || 1)) break;
+      page++;
+    }
+
+    // All results from /tuitionRates?grade= are configured records
+    const configuredRates = existingRates.filter(
+      (r) => r.universityStudentsRate && r.universityStudentsRate.minimumRate != null
+    );
+
+    let template;
+    if (configuredRates.length) {
+      template = configuredRates[0];
+    } else if (GRADE_FALLBACK_RATES[grade.title]) {
+      template = GRADE_FALLBACK_RATES[grade.title];
+      console.log(`[FALL] "${grade.title}" — no DB rates, using production fallback`);
+    } else {
+      console.log(`[SKIP] "${grade.title}" — no configured rates to copy from`);
+      totalSkipped++;
+      continue;
+    }
+    const configuredSubjectIds = new Set(
+      configuredRates.map((r) => (r.subject && (r.subject.id || r.subject._id)))
+    );
+
+    const missingSubjects = subjects.filter(
+      (s) => !configuredSubjectIds.has(s.id || s._id)
+    );
+
+    if (!missingSubjects.length) {
+      console.log(`[OK]   "${grade.title}" — all ${subjects.length} subjects have rates`);
+      continue;
+    }
+
+    console.log(`[FIX]  "${grade.title}" — ${missingSubjects.length} subject(s) missing rates:`);
+
+    for (const subject of missingSubjects) {
+      const subjectId = subject.id || subject._id;
+      const payload = {
+        subject: subjectId,
+        grade: gradeId,
+        universityStudentsRate: {
+          minimumRate: template.universityStudentsRate.minimumRate,
+          maximumRate: template.universityStudentsRate.maximumRate,
+        },
+        partTimeTutorRate: {
+          minimumRate: template.partTimeTutorRate.minimumRate,
+          maximumRate: template.partTimeTutorRate.maximumRate,
+        },
+        fullTimeTutorRate: {
+          minimumRate: template.fullTimeTutorRate.minimumRate,
+          maximumRate: template.fullTimeTutorRate.maximumRate,
+        },
+        moeTeacherRate: {
+          minimumRate: template.moeTeacherRate.minimumRate,
+          maximumRate: template.moeTeacherRate.maximumRate,
+        },
+      };
+
+      if (DRY_RUN) {
+        console.log(`   [DRY] Would create rate for "${subject.title}"`);
+        totalCreated++;
+        continue;
+      }
+
+      const createRes = await api('/tuitionRates', {
+        method: 'POST',
+        token,
+        body: payload,
+      });
+
+      if (createRes.status === 201) {
+        console.log(`   ✓ Created rate for "${subject.title}"`);
+        totalCreated++;
+      } else if (createRes.status === 400 || createRes.status === 409) {
+        console.log(`   ~ Already exists for "${subject.title}" — skipped`);
+        totalAlreadyExist++;
+      } else {
+        console.error(`   ✗ Failed for "${subject.title}" — ${createRes.status}: ${JSON.stringify(createRes.data)}`);
+      }
+    }
+  }
+
+  console.log(`\n${'─'.repeat(60)}`);
+  if (DRY_RUN) {
+    console.log(`  DRY RUN complete — ${totalCreated} record(s) would be created`);
+    console.log(`  Run with --apply flag to actually create them`);
+  } else {
+    console.log(`  Created       : ${totalCreated}`);
+    console.log(`  Already exist : ${totalAlreadyExist}`);
+    console.log(`  Grades skipped: ${totalSkipped}`);
+  }
+  console.log(`${'─'.repeat(60)}\n`);
+}
+
+run().catch((err) => {
+  console.error('Unexpected error:', err.message);
+  process.exit(1);
+});

--- a/src/services/grade.service.js
+++ b/src/services/grade.service.js
@@ -125,23 +125,10 @@ const getSubjectsForGrades = async (gradeIds, options = {}) => {
 const getGradesWithTuitionRateCounts = async () => {
   const grades = await Grade.aggregate([
     {
-      $lookup: {
-        from: 'tuitionrates',
-        localField: '_id',
-        foreignField: 'grade',
-        as: 'tuitionRates',
-      },
-    },
-    {
-      $addFields: {
-        tuitionRateCount: { $size: '$tuitionRates' },
-      },
-    },
-    {
       $project: {
         title: 1,
         description: 1,
-        tuitionRateCount: 1,
+        tuitionRateCount: { $size: { $ifNull: ['$subjects', []] } },
       },
     },
     {

--- a/src/services/tuitionRates.service.js
+++ b/src/services/tuitionRates.service.js
@@ -53,17 +53,55 @@ const queryTuitionRates = async (filter, options) => {
 };
 
 const getTuitionRatesByGradeId = async (gradeId, filter, options) => {
-  const query = await buildTuitionRateSearchQuery({
-    grade: gradeId,
-    ...filter,
+  const grade = await Grade.findById(gradeId).populate('subjects').lean();
+  if (!grade) {
+    return { results: [], page: 1, limit: 10, totalPages: 0, totalResults: 0 };
+  }
+
+  const subjects = grade.subjects || [];
+
+  // Fetch all configured rates for this grade in one query
+  const existingRates = await TuitionRates.find({ grade: gradeId }).populate('subject').lean();
+  const ratesBySubjectId = new Map(existingRates.map((r) => [r.subject._id.toString(), r]));
+
+  // Build merged list — every subject appears, rate fields are null if not configured
+  let merged = subjects.map((subject) => {
+    const rate = ratesBySubjectId.get(subject._id.toString());
+    if (rate) return rate;
+    return {
+      subject: { id: subject._id, _id: subject._id, title: subject.title },
+      grade: { id: grade._id, _id: grade._id, title: grade.title },
+      universityStudentsRate: null,
+      partTimeTutorRate: null,
+      fullTimeTutorRate: null,
+      moeTeacherRate: null,
+    };
   });
 
-  const tuitionRates = await TuitionRates.paginate(query, {
-    ...options,
-    populate: 'grade subject',
-  });
+  // Apply optional search/subject filters
+  const searchTerm = typeof filter.search === 'string' ? filter.search.trim() : '';
+  if (searchTerm) {
+    const searchRegex = new RegExp(escapeRegex(searchTerm), 'i');
+    merged = merged.filter((r) => searchRegex.test((r.subject && r.subject.title) || ''));
+  }
+  if (filter.subject) {
+    merged = merged.filter((r) => {
+      try {
+        return (r.subject && r.subject._id && r.subject._id.toString()) === filter.subject;
+      } catch (e) {
+        return false;
+      }
+    });
+  }
 
-  return tuitionRates;
+  // Manual pagination (paginate plugin not usable on plain arrays)
+  const totalResults = merged.length;
+  const limit = parseInt(options.limit, 10) > 0 ? parseInt(options.limit, 10) : 10;
+  const page = parseInt(options.page, 10) > 0 ? parseInt(options.page, 10) : 1;
+  const totalPages = Math.ceil(totalResults / limit) || 1;
+  const results = merged.slice((page - 1) * limit, page * limit);
+
+  return { results, page, limit, totalPages, totalResults };
 };
 
 /**


### PR DESCRIPTION
Summary: Fixed tuition rates table not showing all subjects for a grade. 
Previously only subjects with configured rates appeared. Now all subjects 
are displayed with null rate fields for unconfigured ones.

Changes:

Frontend:
* no frontend changes in this PR

Backend:
* Refactored getTuitionRatesByGradeId to fetch all grade subjects and 
  merge with existing tuition rate records
* Subjects with no configured rate now appear in the table with null 
  rate fields instead of being hidden
* Applied manual pagination on the merged result array
* Retained search and subject filter support on the merged result set
* Replaced expensive $lookup join in getGradesWithTuitionRateCounts 
  with lightweight $project counting subjects directly from grade document
* Added seed-missing-rates.js utility script to backfill missing rate 
  records via the existing API

File changed:
* src/services/tuitionRates.service.js
* src/services/grade.service.js
* scripts/seed-missing-rates.js

Root Cause:
* getTuitionRatesByGradeId only queried configured tuition rate records
  so subjects with no rate were never returned to the frontend

Result:
* All subjects now appear in the rates table regardless of whether 
  a rate has been configured
* Unconfigured subjects show null rate fields which the frontend 
  handles gracefully
* Grade listing aggregation is faster with no unnecessary $lookup join

Checklist:
* Self-reviewed code
* Verified all subjects appear in the rates table for each grade
* Verified configured rates still display correct values
* Verified search filter works on the merged result set
* Verified pagination works correctly on merged results
* Verified no other tuition rate functionality is affected