### PR TITLE
fix(certificates): support mixed string and object formats for certificates and qualifications

### DIFF
--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -210,7 +210,7 @@ const userSchema = mongoose.Schema(
       default: '',
     },
     certificatesAndQualifications: {
-      type: [String],
+      type: [mongoose.Schema.Types.Mixed],
       default: [],
     },
     gender: {

--- a/src/services/accountSync.service.js
+++ b/src/services/accountSync.service.js
@@ -20,12 +20,15 @@ const getTutorCertificatesFromUser = (user, tutor) => {
 
   const existingCertificates = Array.isArray(tutor.certificatesAndQualifications) ? tutor.certificatesAndQualifications : [];
 
-  return user.certificatesAndQualifications.map((certificateUrl) => {
-    const existingCertificate = existingCertificates.find((certificate) => certificate.url === certificateUrl);
+  return user.certificatesAndQualifications.map((certificate) => {
+    if (certificate && typeof certificate === 'object' && certificate.url) {
+      return { type: certificate.type || 'Certificate', url: certificate.url };
+    }
 
+    const existingCertificate = existingCertificates.find((c) => c.url === certificate);
     return {
       type: (existingCertificate && existingCertificate.type) || 'Certificate',
-      url: certificateUrl,
+      url: certificate,
     };
   });
 };
@@ -36,7 +39,11 @@ const getUserCertificatesFromTutor = (tutor) => {
   }
 
   return tutor.certificatesAndQualifications
-    .map((certificate) => (typeof certificate === 'string' ? certificate : certificate.url))
+    .map((certificate) => {
+      if (typeof certificate === 'string') return { type: 'Certificate', url: certificate };
+      if (certificate && certificate.url) return { type: certificate.type || 'Certificate', url: certificate.url };
+      return null;
+    })
     .filter(Boolean);
 };
 

--- a/src/validations/tutor.validation.js
+++ b/src/validations/tutor.validation.js
@@ -305,7 +305,9 @@ const tutorUserProfileFields = {
   teachingSummary: Joi.string().allow('').max(750),
   studentResults: Joi.string().allow('').max(750),
   sellingPoints: Joi.string().allow('').max(750),
-  certificatesAndQualifications: Joi.array().items(Joi.string()),
+  certificatesAndQualifications: Joi.array().items(
+    Joi.alternatives().try(Joi.string(), Joi.object({ type: Joi.string().allow(''), url: Joi.string() }))
+  ),
   language: Joi.string(),
   timeZone: Joi.string(),
   rate: Joi.string(),


### PR DESCRIPTION
Ticket: https://softvilmedia-team.atlassian.net/browse/TM-1039

Summary: Fixed certificatesAndQualifications field to correctly handle 
both plain URL strings and {type, url} objects across the model, 
validation, and account sync service.

Changes:

Frontend:
* no frontend changes in this PR

Backend:
* Changed certificatesAndQualifications type from [String] to [Mixed] 
  in user model to support both string and object formats
* Updated Joi validation to accept either a plain string or an object 
  with {type, url} shape for certificatesAndQualifications
* Updated getTutorCertificatesFromUser in accountSync service to handle 
  both plain URL strings and {type, url} objects
* Updated getUserCertificatesFromTutor in accountSync service to map 
  both string and object formats to consistent {type, url} shape

File changed:
* src/models/user.model.js
* src/validations/tutor.validation.js
* src/services/accountSync.service.js

Root Cause:
* certificatesAndQualifications was typed as [String] in the user model
  but the frontend was sending {type, url} objects, causing data to be
  stored and synced incorrectly

Result:
* Both plain URL strings and {type, url} objects are now accepted and
  handled correctly across model, validation and sync service
* No data loss during account sync between user and tutor documents

Checklist:
* Self-reviewed code
* Verified certificates save correctly in both string and object format
* Verified account sync correctly maps certificates between user and tutor
* Verified validation accepts both string and object formats
* Verified no other user or tutor functionality is affected