### PR TITLE
Enable Sentry Logs and Production Environment Configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,6 +8,8 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
+      - key: APP_ENV
+        value: production
       - key: PORT
         value: 3000
       - key: JWT_SECRET

--- a/src/config/sentry.js
+++ b/src/config/sentry.js
@@ -138,6 +138,8 @@ if (isEnabled) {
     dsn: config.sentry.dsn,
     environment: config.sentry.environment,
     release: config.sentry.release,
+    integrations: [Sentry.consoleLoggingIntegration({ levels: ['log', 'warn', 'error'] })],
+    enableLogs: true,
     sendDefaultPii: false,
     tracesSampleRate: config.sentry.environment === 'production' ? 0.05 : 0.1,
     beforeSend,


### PR DESCRIPTION
## Summary
Adds Sentry log forwarding for the API and ensures production deployments are explicitly tagged with the `production` Sentry environment.

## Changes

### Frontend
No frontend changes in this PR

### Backend
* Enabled Sentry logs with `enableLogs: true`
* Added Sentry console logging integration for `log`, `warn`, and `error`
* Added `APP_ENV=production` to Render production env config

## Files Changed
* `src/config/sentry.js`
* `render.yaml`

## Root Cause
* Sentry was initialized for error reporting, but logs were not enabled or forwarded through the SDK.
* Production environment tagging relied on fallback behavior instead of an explicit `APP_ENV=production`.

## Result
* API logs can now be sent to Sentry.
* Production Sentry events, logs, and metrics are labeled under the `production` environment.
* Sentry logs and metrics were verified locally with successful flushes.
