### PR TITLE
fix(TM-1082): use environment-specific URL in tutor approval email login button

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -582,7 +582,7 @@ TuitionLanka – Learn Better, Achieve More
 const sendTutorApprovedEmail = async (to, tutorName) => {
   try {
     const subject = 'Your Tutor Registration is Approved – TuitionLanka';
-    const signInUrl = 'https://www.tuitionlanka.com?login=true';
+    const signInUrl = `${config.app.userUrl}?login=true`;
     let tutorRequestsTelegramGroupUrl = '';
 
     try {


### PR DESCRIPTION
## Summary
- Replaced hardcoded production URL in tutor approval email with environment-aware config variable
- Login button in approval email now correctly points to QA or Production based on deployment environment

## Changes
- `src/services/email.service.js` — `sendTutorApprovedEmail`
  - Before: `const signInUrl = 'https://www.tuitionlanka.com?login=true'`
  - After: `const signInUrl = \`${config.app.userUrl}?login=true\``

## How It Works
- `config.app.userUrl` reads from `USER_APP_URL` environment variable
- Azure QA sets `USER_APP_URL=https://qa.tuitionlanka.com`
- Azure Production sets `USER_APP_URL=https://www.tuitionlanka.com`
- Fallback default: `https://www.tuitionlanka.com`

## Test Plan
- [ ] Trigger tutor approval on QA — verify email login button links to `https://qa.tuitionlanka.com?login=true`
- [ ] Confirm Production environment still uses `https://www.tuitionlanka.com?login=true`
- [ ] Verify no other email links are affected
