### PR TITLE
Add full dashboard endpoint to consolidate API calls

### DIFF
--- a/src/controllers/dashboard.controller.js
+++ b/src/controllers/dashboard.controller.js
@@ -6,6 +6,12 @@ const getDashboardSummary = catchAsync(async (req, res) => {
   res.send(summary);
 });
 
+const getFullDashboard = catchAsync(async (req, res) => {
+  const data = await dashboardService.getFullDashboard();
+  res.send(data);
+});
+
 module.exports = {
   getDashboardSummary,
+  getFullDashboard,
 };

--- a/src/routes/v1/dashboard.route.js
+++ b/src/routes/v1/dashboard.route.js
@@ -5,5 +5,6 @@ const dashboardController = require('../../controllers/dashboard.controller');
 const router = express.Router();
 
 router.get('/summary', auth('getUsers'), dashboardController.getDashboardSummary);
+router.get('/full', auth('getUsers'), dashboardController.getFullDashboard);
 
 module.exports = router;

--- a/src/services/dashboard.service.js
+++ b/src/services/dashboard.service.js
@@ -1,5 +1,160 @@
-const { User, Tutor, RequestTutor } = require('../models');
+const { User, Tutor, RequestTutor, Inquiry } = require('../models');
 
+// Helpers
+
+const ASSIGNED_STATUSES = ['Rejected', 'Tutor Assigned', 'Assiged', 'Assigned'];
+
+/** Return midnight (UTC) of a date offset by `days` from today */
+const dayOffset = (days) => {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d;
+};
+
+/** Build a { today, last7Days, prev7Days } trend object for a given model + optional match filter */
+const buildTrend = async (Model, matchFilter = {}) => {
+  const todayStart = dayOffset(0);
+  const tomorrowStart = dayOffset(1);
+  const last7Start = dayOffset(-6); // inclusive of today = 7 days
+  const prev7Start = dayOffset(-13);
+
+  const [today, last7Days, prev7Days] = await Promise.all([
+    Model.countDocuments({ ...matchFilter, createdAt: { $gte: todayStart, $lt: tomorrowStart } }),
+    Model.countDocuments({ ...matchFilter, createdAt: { $gte: last7Start, $lt: tomorrowStart } }),
+    Model.countDocuments({ ...matchFilter, createdAt: { $gte: prev7Start, $lt: last7Start } }),
+  ]);
+
+  return { today, last7Days, prev7Days };
+};
+
+/** Build an array of { date: 'YYYY-MM-DD', count: N } for the last `days` days */
+const buildDailyChart = async (Model, matchFilter = {}, days = 30) => {
+  const startDate = dayOffset(-(days - 1));
+  const endDate = dayOffset(1); // exclusive: tomorrow midnight
+
+  const pipeline = [
+    { $match: { ...matchFilter, createdAt: { $gte: startDate, $lt: endDate } } },
+    {
+      $group: {
+        _id: {
+          $dateToString: { format: '%Y-%m-%d', date: '$createdAt', timezone: 'UTC' },
+        },
+        count: { $sum: 1 },
+      },
+    },
+  ];
+
+  const raw = await Model.aggregate(pipeline);
+  const byDate = Object.fromEntries(raw.map((r) => [r._id, r.count]));
+
+  // Build a complete day-by-day array (fill gaps with 0)
+  return Array.from({ length: days }, (_, i) => {
+    const d = dayOffset(-(days - 1 - i));
+    const key = d.toISOString().slice(0, 10);
+    return { date: key, count: byDate[key] || 0 };
+  });
+};
+
+/** Count tutor requests that are considered "open" (no tutor fully assigned) */
+const countOpenTutorRequests = async () => {
+  // A request is open if its status is NOT one of the closed statuses
+  // AND it has no tutor blocks or at least one tutor block has no assignedTutor.
+  const result = await RequestTutor.aggregate([
+    {
+      $match: {
+        status: { $nin: ASSIGNED_STATUSES },
+      },
+    },
+    {
+      $addFields: {
+        tutorBlocks: { $ifNull: ['$tutors', []] },
+      },
+    },
+    {
+      $addFields: {
+        hasNoTutorBlocks: {
+          $eq: [{ $size: '$tutorBlocks' }, 0],
+        },
+        hasUnassignedBlock: {
+          $anyElementTrue: {
+            $map: {
+              input: '$tutorBlocks',
+              as: 'block',
+              in: {
+                $or: [
+                  { $eq: ['$$block.assignedTutor', null] },
+                  { $eq: [{ $trim: { input: { $ifNull: ['$$block.assignedTutor', ''] } } }, ''] },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      $match: {
+        $or: [{ hasNoTutorBlocks: true }, { hasUnassignedBlock: true }],
+      },
+    },
+    { $count: 'total' },
+  ]);
+
+  return result.length > 0 ? result[0].total : 0;
+};
+
+/** Build the recent activity feed - top 8 most-recent items across tutors, requests, inquiries */
+const buildRecentActivity = async () => {
+  const LIMIT = 8;
+
+  const [recentTutors, recentRequests, recentInquiries] = await Promise.all([
+    Tutor.find({}).select('fullName email status createdAt').sort({ createdAt: -1 }).limit(LIMIT).lean(),
+
+    RequestTutor.find({}).select('name grade medium status createdAt updatedAt').sort({ updatedAt: -1 }).limit(LIMIT).lean(),
+
+    Inquiry.find({}).select('sender message createdAt').sort({ createdAt: -1 }).limit(LIMIT).lean(),
+  ]);
+
+  const tutorItems = recentTutors.map((t) => ({
+    type: 'tutor',
+    id: String(t._id),
+    name: t.fullName || '',
+    email: t.email || '',
+    status: t.status || 'pending',
+    timestamp: t.createdAt,
+  }));
+
+  const requestItems = recentRequests.map((r) => ({
+    type: 'tutorRequest',
+    id: String(r._id),
+    name: r.name || '',
+    grade: r.grade || '',
+    medium: r.medium || '',
+    status: r.status || 'Pending',
+    timestamp: r.updatedAt || r.createdAt,
+  }));
+
+  const inquiryItems = recentInquiries.map((i) => {
+    const sender = i.sender || {};
+
+    return {
+      type: 'inquiry',
+      id: String(i._id),
+      senderName: sender.name || '',
+      senderEmail: sender.email || '',
+      message: i.message || '',
+      timestamp: i.createdAt,
+    };
+  });
+
+  return [...tutorItems, ...requestItems, ...inquiryItems]
+    .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+    .slice(0, LIMIT);
+};
+
+// Public service functions
+
+/** Existing lightweight summary (kept for backward compatibility) */
 const getDashboardSummary = async () => {
   const [registeredTutors, registeredStudents, requestTutorRequests, registerAsTutorRequests] = await Promise.all([
     User.countDocuments({ role: 'tutor' }),
@@ -16,6 +171,109 @@ const getDashboardSummary = async () => {
   };
 };
 
+/**
+ * Single consolidated endpoint for the admin dashboard.
+ * Replaces 5 separate heavy API calls from the frontend.
+ */
+const getFullDashboard = async () => {
+  const CHART_DAYS = 60;
+
+  const [
+    // Summary counts
+    registeredTutors,
+    registeredStudents,
+    requestTutorRequests,
+    registerAsTutorRequests,
+
+    // 7-day trends
+    tutorTrend,
+    requestTrend,
+    applicationTrend,
+
+    // Chart totals
+    approvedTutorsTotal,
+
+    // Daily chart history for current and previous dashboard windows
+    approvedTutorsChart,
+    tutorRequestsChart,
+    tutorApplicationsChart,
+
+    // Attention panel
+    pendingTutorApplicationsTotal,
+    openTutorRequestsTotal,
+    inquiriesTotal,
+    latestInquiry,
+
+    // Recent activity
+    recentActivity,
+  ] = await Promise.all([
+    // Summary
+    User.countDocuments({ role: 'tutor' }),
+    User.countDocuments({ role: 'user' }),
+    RequestTutor.countDocuments(),
+    Tutor.countDocuments(),
+
+    // Trends
+    buildTrend(Tutor, { status: 'approved' }), // registeredTutors trend
+    buildTrend(RequestTutor), // requestTutorRequests trend
+    buildTrend(Tutor), // registerAsTutorRequests trend
+
+    // Chart totals
+    Tutor.countDocuments({ status: 'approved' }),
+
+    // Chart
+    buildDailyChart(Tutor, { status: 'approved' }, CHART_DAYS),
+    buildDailyChart(RequestTutor, {}, CHART_DAYS),
+    buildDailyChart(Tutor, {}, CHART_DAYS),
+
+    // Attention
+    Tutor.countDocuments({ status: 'pending' }),
+    countOpenTutorRequests(),
+    Inquiry.countDocuments(),
+    Inquiry.findOne({}).sort({ createdAt: -1 }).select('sender').lean(),
+
+    // Recent activity
+    buildRecentActivity(),
+  ]);
+
+  return {
+    summary: {
+      registeredTutors,
+      registeredStudents,
+      requestTutorRequests,
+      registerAsTutorRequests,
+    },
+
+    trends: {
+      registeredTutors: tutorTrend,
+      requestTutorRequests: requestTrend,
+      registerAsTutorRequests: applicationTrend,
+    },
+
+    chart: {
+      approvedTutors: approvedTutorsChart,
+      tutorRequests: tutorRequestsChart,
+      tutorApplications: tutorApplicationsChart,
+      totals: {
+        approvedTutors: approvedTutorsTotal,
+        tutorRequests: requestTutorRequests,
+        tutorApplications: registerAsTutorRequests,
+      },
+      daysIncluded: CHART_DAYS,
+    },
+
+    attention: {
+      pendingTutorApplicationsTotal,
+      openTutorRequestsTotal,
+      inquiriesTotal,
+      latestInquirySenderName: latestInquiry && latestInquiry.sender ? latestInquiry.sender.name || null : null,
+    },
+
+    recentActivity,
+  };
+};
+
 module.exports = {
   getDashboardSummary,
+  getFullDashboard,
 };


### PR DESCRIPTION
## Ticket
[Dashboard API Optimization](https://softvilmedia-team.atlassian.net/browse/TM-1113)

## Summary
Adds a consolidated dashboard analytics endpoint that returns all data required by the admin dashboard in a single API response.

## Changes

### Frontend
* No frontend changes in this PR.

### Backend
* Added `GET /v1/dashboard/full`.
* Added controller support for full dashboard analytics.
* Added dashboard service aggregation for summary counts, trends, chart history, attention counts, and recent activity.
* Preserved existing `/v1/dashboard/summary` endpoint for backward compatibility.
* Added enough chart history to support current and previous dashboard window comparisons.

## Files Changed
* `src/controllers/dashboard.controller.js`
* `src/routes/v1/dashboard.route.js`
* `src/services/dashboard.service.js`

## Root Cause
* N/A - feature/API optimization.

## Result
* Admin dashboard can load analytics data using one API request.
* Backend returns pre-aggregated dashboard data, reducing duplicate frontend requests and client-side processing.