### PR TITLE
fix: update tutor rejection email subject line to Rejected

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -662,7 +662,7 @@ TuitionLanka – Learn Better, Achieve More
  */
 const sendTutorRejectedEmail = async (to, tutorName, customMessage) => {
   try {
-    const subject = 'Your Tutor Registration was Not Approved – TuitionLanka';
+    const subject = 'Your Tutor Registration has been Rejected – TuitionLanka';
     const messageBlock = customMessage ? `\nReason provided by our team:\n${customMessage}\n` : '';
 
     const text = `


### PR DESCRIPTION
## Summary
- Fixed incorrect wording in tutor rejection email subject line

## Changes
- `src/services/email.service.js` — `sendTutorRejectedEmail`
  - Subject: "Your Tutor Registration was Not Approved – TuitionLanka"
  - → "Your Tutor Registration has been Rejected – TuitionLanka"

## Test Plan
- [ ] Admin rejects a tutor → verify email subject shows "has been Rejected"