### PR TITLE
fix: update email template images to PNG format for transparent background

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -27,8 +27,8 @@ const sendEmail = async (to, subject, text, html) => {
 
 const normalizeBaseUrl = (url) => String(url || '').replace(/\/+$/, '');
 
-const LOGO_URL = 'https://www.tuitionlanka.com/Emale_template_logo.jpeg';
-const ICON_URL = 'https://www.tuitionlanka.com/Email_template_icon.jpeg';
+const LOGO_URL = `${config.app.userUrl}/Emale_template_logo.png`;
+const ICON_URL = `${config.app.userUrl}/Email_template_icon.png`;
 
 const buildEmailHtml = (bodyContent) => `
   <div style="background-color:#EFF5FF;padding:40px 0;font-family:Arial,Helvetica,sans-serif;">


### PR DESCRIPTION
## Summary
- Replaced hardcoded `www.tuitionlanka.com` JPEG image URLs with environment-aware PNG URLs (`config.app.userUrl`)
- PNG format supports transparent backgrounds, fixing the visible white box around the logo and icon in email templates
- Images need to be deployed to QA frontend (`qa.tuitionlanka.com/public/`) for emails to render correctly

## Test plan
- [ ] Deploy updated PNG files to QA frontend
- [ ] Trigger any email (registration, approval, rejection, etc.)
- [ ] Confirm logo and icon render cleanly without background mismatch in Gmail