### PR TITLE
fix: allow empty string for avatar field on user update

### DIFF
--- a/src/validations/user.validation.js
+++ b/src/validations/user.validation.js
@@ -67,7 +67,7 @@ const updateUser = {
       subjects: Joi.optional(),
       timeZone: Joi.string(),
       language: Joi.string(),
-      avatar: Joi.string(),
+      avatar: Joi.string().allow(''),
     })
     .unknown(false)
     .min(1),


### PR DESCRIPTION
## Summary
Fixes a validation error thrown by the API when an admin removes their profile photo from the edit profile modal. The frontend sends `avatar: ""` to signal photo removal, but the existing Joi validation rejected empty strings.

## Changes

### Frontend
No frontend changes in this PR.

### Backend
* Updated `avatar` field validation in `updateUser` from `Joi.string()` to `Joi.string().allow('')` to permit empty string values when an admin clears their profile photo

## Files Changed
* `src/validations/user.validation.js`

## Root Cause
* Joi's `string()` validator rejects empty strings by default. When the frontend sent `avatar: ""` to remove the photo, the API returned a `"avatar is not allowed to be empty"` validation error, preventing the save from completing.

## Result
* Admins can now successfully save their profile after removing their current profile photo — the API accepts an empty string for `avatar` and clears the field correctly
