### PR TITLE
fix: add email notifications for admin account status changes (approved, rejected, suspended)

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -4,6 +4,7 @@ const ApiError = require('../utils/ApiError');
 const catchAsync = require('../utils/catchAsync');
 const { userService, tokenService, emailService } = require('../services');
 const { serializeUserProfile } = require('../utils/availability');
+const logger = require('../config/logger');
 
 const createUser = catchAsync(async (req, res) => {
   const user = await userService.createUser(req.body);
@@ -70,7 +71,33 @@ const getUser = catchAsync(async (req, res) => {
 });
 
 const updateUser = catchAsync(async (req, res) => {
-  const user = await userService.updateUserById(req.params.userId, req.body, req.user);
+  const { rejectionMessage, ...updateBody } = req.body;
+
+  const existingUser = await userService.getUserById(req.params.userId);
+  if (!existingUser) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'User not found');
+  }
+  const oldStatus = existingUser.status;
+  const newStatus = updateBody.status;
+
+  const user = await userService.updateUserById(req.params.userId, updateBody, req.user);
+
+  // Fire status-change emails (fire-and-forget — never block the response)
+  if (newStatus && newStatus !== oldStatus) {
+    const fireEmail = async () => {
+      try {
+        if (newStatus === 'rejected') {
+          await emailService.sendAdminRejectedEmail(user.email, user.name, rejectionMessage || '');
+        } else if (newStatus === 'suspended') {
+          await emailService.sendAdminSuspendedEmail(user.email, user.name);
+        }
+      } catch (emailErr) {
+        logger.warn(`Status email failed for user ${user.id} (${oldStatus} → ${newStatus}): ${emailErr.message}`);
+      }
+    };
+    fireEmail();
+  }
+
   res.send(serializeUserProfile(user));
 });
 

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -86,7 +86,9 @@ const updateUser = catchAsync(async (req, res) => {
   if (newStatus && newStatus !== oldStatus) {
     const fireEmail = async () => {
       try {
-        if (newStatus === 'rejected') {
+        if (newStatus === 'approved') {
+          await emailService.sendAdminApprovedEmail(user.email, user.name);
+        } else if (newStatus === 'rejected') {
           await emailService.sendAdminRejectedEmail(user.email, user.name, rejectionMessage || '');
         } else if (newStatus === 'suspended') {
           await emailService.sendAdminSuspendedEmail(user.email, user.name);

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -1027,6 +1027,61 @@ Tuition Lanka – Learn Better, Achieve More
 };
 
 /**
+ * Send admin account approved/reactivated email
+ * @param {string} to - Admin's email address
+ * @param {string} adminName - Admin's name
+ * @returns {Promise}
+ */
+const sendAdminApprovedEmail = async (to, adminName) => {
+  try {
+    const adminWebsiteUrl = process.env.ADMIN_WEBSITE_URL || 'http://localhost:3000';
+    const signInUrl = `${adminWebsiteUrl}/signin`;
+    const subject = 'Your Admin Account has been Approved – TuitionLanka';
+
+    const text = `
+Dear ${adminName},
+
+Great news! Your TuitionLanka admin account has been approved and is now active.
+
+You can log in to the platform using the link below:
+${signInUrl}
+
+If you have any questions, please contact our support team.
+
+Warm regards,
+The TuitionLanka Team
+TuitionLanka – Learn Better, Achieve More
+`;
+
+    const html = buildEmailHtml(`
+      <p style="color:#235ED5;font-size:18px;font-weight:bold;text-align:center;margin:0 0 20px;">Dear ${adminName},</p>
+      <p style="color:#374151;font-size:15px;line-height:1.7;margin:0 0 16px;">
+        Great news! Your <strong>Tuition Lanka</strong> admin account has been <strong style="color:#16a34a;">approved</strong> and is now active.
+        You can log in to the platform and access the admin portal.
+      </p>
+      <p style="text-align:center;margin:28px 0;">
+        <a href="${signInUrl}"
+           style="background-color:#235ED5;color:#fff;padding:13px 32px;border-radius:8px;text-decoration:none;font-weight:bold;font-size:15px;">
+          Log In to Tuition Lanka
+        </a>
+      </p>
+      <p style="color:#6b7280;font-size:13px;margin:0 0 20px;">
+        Or copy this link into your browser:<br/>
+        <a href="${signInUrl}" style="color:#235ED5;word-break:break-all;">${signInUrl}</a>
+      </p>
+      <p style="color:#374151;font-size:15px;line-height:1.7;margin-top:16px;">
+        If you have any questions, please contact our support team.
+      </p>
+    `);
+
+    await transport.sendMail({ from: config.email.from, to, subject, text, html });
+  } catch (err) {
+    logger.error(`Failed to send admin approved email to ${to}:`, err);
+    throw new Error('Admin approved email failed');
+  }
+};
+
+/**
  * Send admin account rejection email
  * @param {string} to - Admin's email address
  * @param {string} adminName - Admin's name
@@ -1141,6 +1196,7 @@ module.exports = {
   sendTutorRejectedEmail,
   sendTutorSuspendedEmail,
   sendAdminInviteEmail,
+  sendAdminApprovedEmail,
   sendAdminRejectedEmail,
   sendAdminSuspendedEmail,
 };

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -1026,6 +1026,105 @@ Tuition Lanka – Learn Better, Achieve More
   }
 };
 
+/**
+ * Send admin account rejection email
+ * @param {string} to - Admin's email address
+ * @param {string} adminName - Admin's name
+ * @param {string} customMessage - Optional rejection reason
+ * @returns {Promise}
+ */
+const sendAdminRejectedEmail = async (to, adminName, customMessage) => {
+  try {
+    const subject = 'Your Admin Account has been Rejected – TuitionLanka';
+    const messageBlock = customMessage ? `\nReason provided by our team:\n${customMessage}\n` : '';
+
+    const text = `
+Dear ${adminName},
+
+We regret to inform you that your TuitionLanka admin account has been rejected.
+${messageBlock}
+If you believe this is a mistake or would like to discuss further, please contact our support team.
+
+Thank you for your understanding.
+
+Warm regards,
+The TuitionLanka Team
+TuitionLanka – Learn Better, Achieve More
+`;
+
+    const messageHtml = customMessage
+      ? `<div style="background-color:#fef2f2;border-left:4px solid #ef4444;padding:14px 18px;border-radius:4px;margin:20px 0;">
+           <p style="margin:0;color:#7f1d1d;font-size:14px;"><strong>Reason provided by our team:</strong></p>
+           <p style="margin:8px 0 0;color:#991b1b;white-space:pre-wrap;">${customMessage}</p>
+         </div>`
+      : '';
+
+    const html = buildEmailHtml(`
+      <p style="color:#235ED5;font-size:18px;font-weight:bold;text-align:center;margin:0 0 20px;">Dear ${adminName},</p>
+      <p style="color:#374151;font-size:15px;line-height:1.7;margin:0 0 16px;">
+        We regret to inform you that your <strong>Tuition Lanka</strong> admin account has been <strong style="color:#dc2626;">Rejected</strong>.
+      </p>
+      ${messageHtml}
+      <p style="color:#374151;font-size:15px;line-height:1.7;margin-top:16px;">
+        If you believe this is a mistake or would like to discuss further, please contact our support team.
+        Thank you for your understanding.
+      </p>
+    `);
+
+    await transport.sendMail({ from: config.email.from, to, subject, text, html });
+  } catch (err) {
+    logger.error(`Failed to send admin rejected email to ${to}:`, err);
+    throw new Error('Admin rejected email failed');
+  }
+};
+
+/**
+ * Send admin account suspension email
+ * @param {string} to - Admin's email address
+ * @param {string} adminName - Admin's name
+ * @returns {Promise}
+ */
+const sendAdminSuspendedEmail = async (to, adminName) => {
+  try {
+    const subject = 'Your Admin Account has been Suspended – TuitionLanka';
+
+    const text = `
+Dear ${adminName},
+
+We are writing to inform you that your TuitionLanka admin account has been suspended.
+
+During the suspension period, you will not be able to log in or access the platform.
+
+If you believe this is a mistake or would like to appeal, please contact our support team directly.
+
+Thank you for your understanding.
+
+Warm regards,
+The TuitionLanka Team
+TuitionLanka – Learn Better, Achieve More
+`;
+
+    const html = buildEmailHtml(`
+      <p style="color:#235ED5;font-size:18px;font-weight:bold;text-align:center;margin:0 0 20px;">Dear ${adminName},</p>
+      <p style="color:#374151;font-size:15px;line-height:1.7;margin:0 0 16px;">
+        We are writing to inform you that your <strong>Tuition Lanka</strong> admin account has been <strong>suspended</strong>.
+      </p>
+      <div style="background:#f3f4f6;border-left:4px solid #6b7280;border-radius:4px;padding:14px 18px;margin:20px 0;">
+        <p style="margin:0;color:#374151;font-size:14px;">During the suspension period, you will not be able to log in or access the platform.</p>
+      </div>
+      <p style="color:#374151;font-size:15px;line-height:1.7;">
+        If you believe this is a mistake or would like to appeal, please contact our support team directly.
+        Thank you for your understanding.
+      </p>
+    `);
+
+    await transport.sendMail({ from: config.email.from, to, subject, text, html });
+  } catch (err) {
+    logger.error(`Failed to send admin suspended email to ${to}:`, err);
+    throw new Error('Admin suspended email failed');
+  }
+};
+
 module.exports = {
   transport,
   sendEmail,
@@ -1042,4 +1141,6 @@ module.exports = {
   sendTutorRejectedEmail,
   sendTutorSuspendedEmail,
   sendAdminInviteEmail,
+  sendAdminRejectedEmail,
+  sendAdminSuspendedEmail,
 };

--- a/src/validations/user.validation.js
+++ b/src/validations/user.validation.js
@@ -68,6 +68,7 @@ const updateUser = {
       timeZone: Joi.string(),
       language: Joi.string(),
       avatar: Joi.string().allow(''),
+      rejectionMessage: Joi.string().allow('').max(1000).optional(),
     })
     .unknown(false)
     .min(1),


### PR DESCRIPTION
## Summary
When an admin account status is changed to Approved, Rejected, or Suspended from the Users page, no email was sent to the affected administrator. This fix mirrors the existing tutor status-change email pattern for admin accounts.

## Changes

### Frontend
* No frontend changes in this PR

### Backend
* Added `sendAdminApprovedEmail(to, adminName)` — reactivation email with sign-in button
* Added `sendAdminRejectedEmail(to, adminName, customMessage)` — rejection email with optional reason block
* Added `sendAdminSuspendedEmail(to, adminName)` — suspension notice email
* Updated `user.controller.js` `updateUser` handler to capture old status before update, then fire-and-forget the appropriate email when status transitions to `approved`, `rejected`, or `suspended` (identical pattern to `tutor.controller.js`)
* Added `rejectionMessage` (`string, max 1000, optional`) to the `updateUser` Joi validation schema so the frontend can pass a custom rejection reason

## Files Changed
* `src/services/email.service.js`
* `src/controllers/user.controller.js`
* `src/validations/user.validation.js`

## Root Cause
* `user.controller.js` called `userService.updateUserById` and returned immediately — no status comparison, no email logic — while `tutor.controller.js` already had the full pattern implemented
* `user.validation.js` did not allow `rejectionMessage` in the request body, so it would have been stripped by Joi even if sent

## Result
* Changing an admin account to Rejected sends an email to the admin with an optional reason provided by the operator
* Changing an admin account to Suspended sends an email informing the admin their access has been restricted
* Reactivating (Approved) an admin from Rejected or Suspended sends a confirmation email with a sign-in link
* Emails are fire-and-forget — a failure logs a warning but never blocks the API response